### PR TITLE
rpcc: Simplify net.Conn to io.ReadWriteCloser

### DIFF
--- a/rpcc/doc.go
+++ b/rpcc/doc.go
@@ -22,7 +22,7 @@ The user must close the connection when finnished with it:
 A custom dialer can be used to change the websocket lib or communicate
 over other protocols.
 
-	netDial := func(ctx context.Context, addr string) (net.Conn, error) {
+	netDial := func(ctx context.Context, addr string) (io.ReadWriteCloser, error) {
 		conn, err := net.Dial("tcp", addr)
 		if err != nil {
 			// Handle error.

--- a/rpcc/socket.go
+++ b/rpcc/socket.go
@@ -13,7 +13,7 @@ type wsConn interface {
 }
 
 // wsReadWriteCloser wraps a gorilla/websocket connection
-// and implements the net.Conn interface.
+// and implements io.Reader and io.Writer.
 type wsReadWriteCloser struct {
 	wsConn
 	r io.Reader

--- a/rpcc/socket.go
+++ b/rpcc/socket.go
@@ -2,49 +2,30 @@ package rpcc
 
 import (
 	"io"
-	"net"
-	"time"
 
 	"github.com/gorilla/websocket"
 )
 
-type websocketConn interface {
+type wsConn interface {
 	NextReader() (messageType int, r io.Reader, err error)
 	NextWriter(messageType int) (io.WriteCloser, error)
 	Close() error
-	LocalAddr() net.Addr
-	RemoteAddr() net.Addr
-	SetReadDeadline(t time.Time) error
-	SetWriteDeadline(t time.Time) error
 }
 
-// wsNetConn wraps a gorilla/websocket connection
+// wsReadWriteCloser wraps a gorilla/websocket connection
 // and implements the net.Conn interface.
-type wsNetConn struct {
-	conn websocketConn
-	r    io.Reader
+type wsReadWriteCloser struct {
+	wsConn
+	r io.Reader
 }
 
 var (
-	_ net.Conn = (*wsNetConn)(nil)
+	_ io.ReadWriteCloser = (*wsReadWriteCloser)(nil)
 )
 
-// Implement net.Conn.
-func (cw *wsNetConn) LocalAddr() net.Addr                { return cw.conn.LocalAddr() }
-func (cw *wsNetConn) RemoteAddr() net.Addr               { return cw.conn.RemoteAddr() }
-func (cw *wsNetConn) SetReadDeadline(t time.Time) error  { return cw.conn.SetReadDeadline(t) }
-func (cw *wsNetConn) SetWriteDeadline(t time.Time) error { return cw.conn.SetWriteDeadline(t) }
-func (cw *wsNetConn) SetDeadline(t time.Time) error {
-	err := cw.SetReadDeadline(t)
-	if err != nil {
-		return err
-	}
-	return cw.SetWriteDeadline(t)
-}
-
 // Read calls Read on the WebSocket Reader and requests the NextReader
-// when io.EOF is encountered. Imlpements io.Reader as part of net.Conn.
-func (cw *wsNetConn) Read(p []byte) (n int, err error) {
+// when io.EOF is encountered. Imlpements io.Reader.
+func (cw *wsReadWriteCloser) Read(p []byte) (n int, err error) {
 	if cw.r != nil {
 		// Check if previous reader still has data in the buffer.
 		// Otherwise pass on to next reader.
@@ -53,7 +34,7 @@ func (cw *wsNetConn) Read(p []byte) (n int, err error) {
 			return n, err
 		}
 	}
-	_, r, err := cw.conn.NextReader()
+	_, r, err := cw.wsConn.NextReader()
 	if err != nil {
 		return 0, err
 	}
@@ -64,9 +45,9 @@ func (cw *wsNetConn) Read(p []byte) (n int, err error) {
 }
 
 // Write requests the NextWriter for the WebSocket and writes the
-// message. Implements io.Writer as part of net.Conn.
-func (cw *wsNetConn) Write(p []byte) (n int, err error) {
-	w, err := cw.conn.NextWriter(websocket.TextMessage)
+// message. Implements io.Writer.
+func (cw *wsReadWriteCloser) Write(p []byte) (n int, err error) {
+	w, err := cw.wsConn.NextWriter(websocket.TextMessage)
 	if err != nil {
 		return 0, err
 	}
@@ -75,9 +56,4 @@ func (cw *wsNetConn) Write(p []byte) (n int, err error) {
 	}
 	err = w.Close()
 	return n, err
-}
-
-// Close calls Close on the underlying connection.
-func (cw *wsNetConn) Close() error {
-	return cw.conn.Close()
 }


### PR DESCRIPTION
This change simplifies the implementation of a custom dialer via `WithDialer` as the connection doesn't need to implement the entire net.Conn interface.

I dislike making breaking changes, but this should simplify any dialer implementation since only the `io.ReadWriteCloser` interface needs to be satisfied. I don't see a use for the full range of `net.Conn` methods internally in `rpcc`, and if there ever is, they can be implemented by other means.

In this case the function signature of the function passed to `WithDialer` would change.