### PR TITLE
rpcc: Add support for <-Stream.Ready()

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -5,30 +5,35 @@ Protocol (CDP) and can be used with any debug target that implements it.
 
 The cdp Client requires an rpcc connection (*rpcc.Conn):
 
-	conn, err := rpcc.Dial("ws://127.0.0.1:9222/f39a3624-e972-4a77-8a5f-6f8c42ef5129")
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	conn, err := rpcc.DialContext(ctx, "ws://127.0.0.1:9222/f39a3624-e972-4a77-8a5f-6f8c42ef5129")
 	if err != nil {
 		// Handle error.
 	}
 	defer conn.Close()
+
 	c := cdp.NewClient(conn)
 	// ...
 
-The devtool package can be used for finding the websocket URL:
+The devtool package can be used for finding the websocket URL (see
+devtool documentation for more):
 
 	devt := devtool.New("http://127.0.0.1:9222")
-	pageTarget, err := devtool.Get(context.Background(), devtool.Page)
+	pg, err := devtool.Get(ctx, devtool.Page)
 	if err != nil {
 		// Handle error.
 	}
-	conn, err := rpcc.Dial(pageTarget.WebSocketDebuggerURL)
+	conn, err := rpcc.Dial(pg.WebSocketDebuggerURL)
 	// ...
 
 Domain methods
 
-Methods can be invoked from the Client:
+Domain methods are used to perform actions or request data over the
+Chrome Debugging Protocol.
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+Methods can be invoked from the Client:
 
 	c := cdp.NewClient(conn)
 	nav, err := c.Page.Navigate(ctx, page.NewNavigateArgs("https://www.google.com"))
@@ -39,20 +44,26 @@ Methods can be invoked from the Client:
 
 Domain events
 
-Events are received with an event client:
+Event clients are used to handle events sent over the protocol. A client
+will buffer all events, preserving order, after creation until it is
+closed, context done or connection closed. Under the hood, an event
+client is a rpcc.Stream.
+
+Create an event client for the DOMContentEventFired event. Call Close
+when the client is no longer used to avoid leaking memory. The client
+will remain active for the duration of the context or until it is
+closed:
 
 	// DOMContentEventFired = DOMContentLoaded.
 	domContentEventFired, err := c.Page.DOMContentEventFired(ctx)
 	if err != nil {
 		// Handle error.
 	}
-	ev, err := domContentEventFired.Recv()
-	if err != nil {
-		// Handle error.
-	}
+	defer domContentEventFired.Close()
 	// ...
 
-Enable must be called before events are triggered for the domain:
+Enable (if available) must be called before events are transmitted over
+the Chrome Debugging Protocol:
 
 	err := c.Page.Enable(ctx)
 	if err != nil {
@@ -60,9 +71,35 @@ Enable must be called before events are triggered for the domain:
 	}
 	// ...
 
-Some events are sent immediately after the call to Enable, it is a good
-idea to create event clients beforehand. The rpcc.Stream will buffer the
-events until they are ready to be received via Recv.
+Calling Enable can result in immediate event transmissions. If these
+events are important, an event client should be created before calling
+Enable.
+
+Wait for an event by calling Recv:
+
+	ev, err := domContentEventFired.Recv()
+	if err != nil {
+		// Handle error.
+	}
+	// ...
+
+The Ready channel can be used to check for pending events or managing
+multiple event handlers:
+
+	go func() {
+		select {
+		case <-domContentEventFired.Ready():
+			_, err := domContentEventFired.Recv() // Does not block here.
+			if err != nil {
+				// Handle error.
+			}
+		case <-loadEventFired.Ready():
+			// Handle loadEventFired.
+		}
+	}()
+	// ...
+
+Calling Close on the event client will also close the Ready channel.
 
 */
 package cdp

--- a/rpcc/stream.go
+++ b/rpcc/stream.go
@@ -188,6 +188,13 @@ func (s *streamClient) recv() (m *streamMsg, err error) {
 		return m, s.userCtx.Err()
 	}
 
+	// Deplete the ready channel in case recv was called without a
+	// previous call to Ready().
+	select {
+	case <-s.ready:
+	default:
+	}
+
 	select {
 	case <-s.userCtx.Done():
 		return m, s.userCtx.Err()


### PR DESCRIPTION
This PR adds support for checking the ready status of a stream. When a stream is ready, RecvMsg will not block.

~~I'm not entirely satisfied with the implementation, it should be cleaned up / simplified in future.~~

Related to #15.