### PR TITLE
rpcc: Change semantics of Stream Ready-channel

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -83,8 +83,8 @@ Wait for an event by calling Recv:
 	}
 	// ...
 
-The Ready channel can be used to check for pending events or managing
-multiple event handlers:
+The Ready channel can be used to check for pending events or
+coordinating between multiple event handlers:
 
 	go func() {
 		select {
@@ -99,7 +99,8 @@ multiple event handlers:
 	}()
 	// ...
 
-Calling Close on the event client will also close the Ready channel.
+Ready must not be called concurrently while relying on the non-blocking
+behavior of Recv.
 
 */
 package cdp


### PR DESCRIPTION
This PR changes the behavior of the Ready-channel for Streams. Empty structs are no longer sent on the channel, instead the channel is closed when a message is ready to be read.

Previously the intent was to allow for safe concurrent (between multiple goroutines) usage of the Ready-channel. However, the way it was implemented could cause confusing behavior when used as intended.

Now the documentation warns about concurrent calls to Ready.

The Ready-channel implementation was moved to messageBuffer for better state synchronization.

Fixes #23.