### PR TITLE
Sync events

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -102,6 +102,17 @@ coordinating between multiple event handlers:
 Ready must not be called concurrently while relying on the non-blocking
 behavior of Recv.
 
+Event clients can be synchronized, realtive to each other, when the order of
+events is important:
+
+	err := cdp.Sync(domContentEventFired, loadEventFired)
+	if err != nil {
+		// Handle error.
+	}
+
+Use the Ready channel to detect which synchronized event client is ready to
+Recv.
+
 */
 package cdp
 

--- a/rpcc/conn.go
+++ b/rpcc/conn.go
@@ -410,7 +410,7 @@ func (c *Conn) notify(method string, data []byte) {
 	c.streamMu.Lock()
 	stream := c.streams[method]
 	if stream != nil {
-		stream.send(method, data)
+		stream.write(method, data)
 	}
 	c.streamMu.Unlock()
 }
@@ -418,7 +418,7 @@ func (c *Conn) notify(method string, data []byte) {
 // listen registers a new stream listener (chan) for the RPC notification
 // method. Returns a function for removing the listener. Error if the
 // connection is closed.
-func (c *Conn) listen(method string, client streamSender) (func(), error) {
+func (c *Conn) listen(method string, w streamWriter) (func(), error) {
 	c.streamMu.Lock()
 	defer c.streamMu.Unlock()
 
@@ -431,7 +431,7 @@ func (c *Conn) listen(method string, client streamSender) (func(), error) {
 		stream = newStreamClients()
 		c.streams[method] = stream
 	}
-	seq := stream.add(client)
+	seq := stream.add(w)
 
 	return func() { stream.remove(seq) }, nil
 }

--- a/rpcc/conn.go
+++ b/rpcc/conn.go
@@ -418,7 +418,7 @@ func (c *Conn) notify(method string, data []byte) {
 // listen registers a new stream listener (chan) for the RPC notification
 // method. Returns a function for removing the listener. Error if the
 // connection is closed.
-func (c *Conn) listen(method string, client *streamClient) (func(), error) {
+func (c *Conn) listen(method string, client streamSender) (func(), error) {
 	c.streamMu.Lock()
 	defer c.streamMu.Unlock()
 
@@ -428,7 +428,7 @@ func (c *Conn) listen(method string, client *streamClient) (func(), error) {
 
 	stream, ok := c.streams[method]
 	if !ok {
-		stream = newStreamService()
+		stream = newStreamClients()
 		c.streams[method] = stream
 	}
 	seq := stream.add(client)

--- a/rpcc/doc.go
+++ b/rpcc/doc.go
@@ -63,5 +63,12 @@ memory:
 	}
 	defer stream.Close()
 
+When order is important, two streams can be synchronized with Sync:
+
+	err := rpcc.Sync(stream1, stream2)
+	if err != nil {
+		// Handle error.
+	}
+
 */
 package rpcc

--- a/rpcc/stream.go
+++ b/rpcc/stream.go
@@ -62,6 +62,23 @@ func (b *messageBuffer) load() {
 	}
 }
 
+// clear removes all messages from buffer.
+func (b *messageBuffer) clear() {
+	b.mu.Lock()
+	backlog := b.backlog
+	b.backlog = nil
+	b.mu.Unlock()
+
+	select {
+	case m := <-b.c:
+		m.next()
+	default:
+	}
+	for _, m := range backlog {
+		m.next()
+	}
+}
+
 func (b *messageBuffer) get() <-chan *message {
 	return b.c
 }

--- a/rpcc/stream_sync.go
+++ b/rpcc/stream_sync.go
@@ -118,6 +118,10 @@ func (s *syncMessageStore) load() {
 // it will not be possible to receive the message from B before the message from
 // A has been received.
 func Sync(s ...Stream) (err error) {
+	if len(s) < 2 {
+		return errors.New("rpcc: Sync: two or more streams must be provided")
+	}
+
 	store := newSyncMessageStore()
 	defer func() {
 		if err != nil {

--- a/rpcc/stream_sync.go
+++ b/rpcc/stream_sync.go
@@ -1,0 +1,125 @@
+package rpcc
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// syncMessageStore loads one message into a
+// messageStorer and waits for message.next
+// to be called before loading the next.
+type syncMessageStore struct {
+	mu      sync.Mutex
+	buf     map[string]streamSender
+	backlog []*streamMsg
+	pending bool
+}
+
+func newSyncMessageStore() *syncMessageStore {
+	return &syncMessageStore{
+		buf: make(map[string]streamSender),
+	}
+}
+
+func (s *syncMessageStore) register(method string, ms streamSender) {
+	s.mu.Lock()
+	s.buf[method] = ms
+	s.mu.Unlock()
+}
+
+// send implements messageStorer, the message is stored
+// in a messageStorer if there are no pending messages,
+// otherwise appended to backlog.
+func (s *syncMessageStore) send(m streamMsg) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	m.next = s.load
+	if s.pending {
+		s.backlog = append(s.backlog, &m)
+		return
+	}
+
+	s.pending = true
+	ms, ok := s.buf[m.method]
+	if !ok {
+		panic("store: bad mojo " + m.method)
+	}
+	ms.send(m)
+}
+
+// load stores the next message into a messageStorer,
+// resets pending status if backlog is empty.
+func (s *syncMessageStore) load() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.backlog) == 0 {
+		s.pending = false
+		return
+	}
+
+	m := s.backlog[0]
+	ms, ok := s.buf[m.method]
+	if !ok {
+		panic("load: bad mojo" + m.method)
+	}
+	ms.send(*m)
+	s.backlog[0] = nil // Remove reference from underlying array.
+	s.backlog = s.backlog[1:]
+}
+
+// Sync synchronizes two or more Streams.
+func Sync(s ...Stream) error {
+	if len(s) == 0 {
+		return nil
+	}
+
+	store := newSyncMessageStore()
+
+	// Validate that the Streams can be synced, they must belong to
+	// the same Conn and the same type of stream cannot be synced
+	// more than once.
+	var conn *Conn
+	prev := make(map[string]struct{})
+	for _, ss := range s {
+		sc, ok := ss.(*streamClient)
+		if !ok {
+			return fmt.Errorf("rpcc: cannot sync Stream of type %T", ss)
+		}
+		if conn == nil {
+			conn = sc.conn
+		}
+		if sc.conn != conn {
+			return errors.New("rpcc: cannot sync Stream with different Conn")
+		}
+		if _, ok := prev[sc.method]; ok {
+			return fmt.Errorf("rpcc: cannot sync Stream with method %q twice", sc.method)
+		}
+		prev[sc.method] = struct{}{}
+
+		// Grab a lock on remove.
+		sc.mu.Lock()
+		defer sc.mu.Unlock()
+
+		if sc.remove == nil {
+			return errors.New("rpcc: cannot sync closed Stream")
+		}
+
+		// Unsubscribe Stream from Conn listen.
+		sc.remove()
+
+		// Register stream client with store.
+		store.register(sc.method, sc)
+
+		// Resubscribe with store as intermediary.
+		remove, err := conn.listen(sc.method, store)
+		if err != nil {
+			return err
+		}
+		sc.remove = remove
+	}
+
+	return nil
+}

--- a/rpcc/stream_sync.go
+++ b/rpcc/stream_sync.go
@@ -113,10 +113,13 @@ func (s *syncMessageStore) load() {
 // multiple streams of the same method to Sync is not supported and will return
 // an error.
 //
-// When two streams, A and B, are in sync they will receive messages in the
-// order that they arrived on Conn. If A and B receive a message, in that order,
-// it will not be possible to receive the message from B before the message from
-// A has been received.
+// A stream that is closed is removed and has no further affect on the streams
+// that were synchronized.
+//
+// When two streams, A and B, are in sync they will both receive messages in the
+// order that they arrived on Conn. If a message for both A and B arrives, in
+// that order, it will not be possible to receive the message from B before the
+// message from A has been received.
 func Sync(s ...Stream) (err error) {
 	if len(s) < 2 {
 		return errors.New("rpcc: Sync: two or more streams must be provided")

--- a/rpcc/stream_sync.go
+++ b/rpcc/stream_sync.go
@@ -104,8 +104,19 @@ func (s *syncMessageStore) load() {
 	s.backlog = s.backlog[1:]
 }
 
-// Sync synchronizes two or more Streams. On error there will be no
-// changes done to the Streams.
+// Sync takes two or more streams and sets them into synchronous operation,
+// relative to each other. This operation cannot be undone. If an error is
+// returned this function is no-op and the streams will continue in asynchronous
+// operation.
+//
+// All streams must belong to the same Conn and they must not be closed. Passing
+// multiple streams of the same method to Sync is not supported and will return
+// an error.
+//
+// When two streams, A and B, are in sync they will receive messages in the
+// order that they arrived on Conn. If A and B receive a message, in that order,
+// it will not be possible to receive the message from B before the message from
+// A has been received.
 func Sync(s ...Stream) (err error) {
 	store := newSyncMessageStore()
 	defer func() {

--- a/rpcc/stream_sync_test.go
+++ b/rpcc/stream_sync_test.go
@@ -1,0 +1,151 @@
+package rpcc
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSync(t *testing.T) {
+	conn, connCancel := newTestStreamConn()
+	defer connCancel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s1, err := NewStream(ctx, "test1", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s1.Close()
+
+	s2, err := NewStream(ctx, "test2", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+
+	// These notifications should disappear after Sync.
+	conn.notify("test1", []byte(strconv.Itoa(1)))
+	conn.notify("test1", []byte(strconv.Itoa(2)))
+
+	err = Sync(s1, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for i := 0; i < 3; i++ {
+			conn.notify("test1", []byte(strconv.Itoa(100+i)))
+		}
+		for i := 0; i < 3; i++ {
+			conn.notify("test2", []byte(strconv.Itoa(200+i)))
+		}
+		for i := 0; i < 4; i++ {
+			conn.notify("test1", []byte(strconv.Itoa(100+i)))
+			conn.notify("test2", []byte(strconv.Itoa(200+i)))
+		}
+	}()
+
+	var got []int
+	for i := 0; i < 14; i++ {
+		var x int
+		select {
+		case <-s1.Ready():
+			err := s1.RecvMsg(&x)
+			if err != nil {
+				t.Error(err)
+			}
+		case <-s2.Ready():
+			err := s2.RecvMsg(&x)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+		got = append(got, x)
+	}
+
+	want := []int{100, 101, 102, 200, 201, 202, 100, 200, 101, 201, 102, 202, 103, 203}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Output differs (-got +want)\n%s", diff)
+	}
+}
+
+type fakeStream struct{}
+
+func (s *fakeStream) Ready() <-chan struct{}      { return nil }
+func (s *fakeStream) RecvMsg(m interface{}) error { return nil }
+func (s *fakeStream) Close() error                { return nil }
+
+var (
+	_ Stream = (*fakeStream)(nil)
+)
+
+func TestSyncError(t *testing.T) {
+	conn1, connCancel1 := newTestStreamConn()
+	defer connCancel1()
+
+	conn2, connCancel2 := newTestStreamConn()
+	defer connCancel2()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s1, err := NewStream(ctx, "test", conn1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s1.Close()
+
+	s2, err := NewStream(ctx, "duplicate", conn1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+
+	s3, err := NewStream(ctx, "duplicate", conn1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s3.Close()
+
+	s4, err := NewStream(ctx, "other-conn", conn2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s4.Close()
+
+	err = Sync(s1, s2)
+	if err != nil {
+		t.Errorf("Sync failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"Invalid stream", func() error { return Sync(&fakeStream{}) }},
+		{"Duplicate stream", func() error { return Sync(s1, s2, s3) }},
+		{"Mixed Conn", func() error { return Sync(s1, s2, s4) }},
+		{"Closed Conn", func() error {
+			conn2.Close()
+			return Sync(s4)
+		}},
+		{"Closed Stream", func() error {
+			s3.Close()
+			return Sync(s3)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil {
+				t.Error("Expected error, got nil")
+			}
+		})
+
+	}
+}

--- a/rpcc/stream_sync_test.go
+++ b/rpcc/stream_sync_test.go
@@ -126,16 +126,17 @@ func TestSyncError(t *testing.T) {
 		name string
 		run  func() error
 	}{
-		{"Invalid stream", func() error { return Sync(&fakeStream{}) }},
+		{"Single stream", func() error { return Sync(s1) }},
+		{"Invalid stream", func() error { return Sync(&fakeStream{}, s1) }},
 		{"Duplicate stream", func() error { return Sync(s1, s2, s3) }},
 		{"Mixed Conn", func() error { return Sync(s1, s2, s4) }},
 		{"Closed Conn", func() error {
 			conn2.Close()
-			return Sync(s4)
+			return Sync(s4, s1)
 		}},
 		{"Closed Stream", func() error {
 			s3.Close()
-			return Sync(s3)
+			return Sync(s3, s1)
 		}},
 	}
 

--- a/rpcc/stream_test.go
+++ b/rpcc/stream_test.go
@@ -145,6 +145,67 @@ func TestStream_Ready_Multiple_Streams(t *testing.T) {
 	}
 }
 
+func TestSync(t *testing.T) {
+	conn, connCancel := newTestStreamConn()
+	defer connCancel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s1, err := NewStream(ctx, "test1", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s1.Close()
+
+	s2, err := NewStream(ctx, "test2", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+
+	err = Sync(s1, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for i := 0; i < 3; i++ {
+			conn.notify("test1", []byte(strconv.Itoa(100+i)))
+		}
+		for i := 0; i < 3; i++ {
+			conn.notify("test2", []byte(strconv.Itoa(200+i)))
+		}
+		for i := 0; i < 4; i++ {
+			conn.notify("test1", []byte(strconv.Itoa(100+i)))
+			conn.notify("test2", []byte(strconv.Itoa(200+i)))
+		}
+	}()
+
+	var got []int
+	for i := 0; i < 14; i++ {
+		var x int
+		select {
+		case <-s1.Ready():
+			err := s1.RecvMsg(&x)
+			if err != nil {
+				t.Error(err)
+			}
+		case <-s2.Ready():
+			err := s2.RecvMsg(&x)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+		got = append(got, x)
+	}
+
+	want := []int{100, 101, 102, 200, 201, 202, 100, 200, 101, 201, 102, 202, 103, 203}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Output differs (-got +want)\n%s", diff)
+	}
+}
+
 func TestStream_Wait_Blocks_After_RecvMsg(t *testing.T) {
 	conn, connCancel := newTestStreamConn()
 	defer connCancel()

--- a/rpcc/stream_test.go
+++ b/rpcc/stream_test.go
@@ -330,7 +330,7 @@ func TestMessageBuffer(t *testing.T) {
 
 	go func() {
 		for i := 0; i < n; i++ {
-			b.store(&streamMsg{data: []byte(strconv.Itoa(i)), next: func() { b.load() }})
+			b.store(&message{data: []byte(strconv.Itoa(i)), next: func() { b.load() }})
 		}
 	}()
 

--- a/rpcc/stream_test.go
+++ b/rpcc/stream_test.go
@@ -269,13 +269,13 @@ func TestMessageBuffer(t *testing.T) {
 
 	go func() {
 		for i := 0; i < n; i++ {
-			b.store(&streamMsg{data: []byte(strconv.Itoa(i))})
+			b.store(&streamMsg{data: []byte(strconv.Itoa(i)), next: func() { b.load() }})
 		}
 	}()
 
 	i := 0
-	for bi := range b.get() {
-		m := bi.message()
+	for m := range b.get() {
+		m.next()
 		if strconv.Itoa(i) != string(m.data) {
 			t.Errorf("Got n = %s, want %d", m.data, i)
 		}

--- a/sync.go
+++ b/sync.go
@@ -1,0 +1,20 @@
+package cdp
+
+import (
+	"github.com/mafredri/cdp/rpcc"
+)
+
+type eventClient interface {
+	rpcc.Stream
+}
+
+// Sync synchronizes two or more event clients.
+// An error will be returned if the event clients do not have the same
+// connection or event clients of the same type are synchronized.
+func Sync(c ...eventClient) error {
+	var s []rpcc.Stream
+	for _, cc := range c {
+		s = append(s, cc)
+	}
+	return rpcc.Sync(s...)
+}

--- a/sync.go
+++ b/sync.go
@@ -8,9 +8,22 @@ type eventClient interface {
 	rpcc.Stream
 }
 
-// Sync synchronizes two or more event clients.
-// An error will be returned if the event clients do not have the same
-// connection or event clients of the same type are synchronized.
+// Sync takes two or more event clients and sets them into synchronous operation,
+// relative to each other. This operation cannot be undone. If an error is
+// returned this function is no-op and the event clients will continue in
+// asynchronous operation.
+//
+// All event clients must belong to the same connection and they must not be
+// closed. Passing multiple clients of the same event type to Sync is not
+// supported and will return an error.
+//
+// An event client that is closed is removed and has no further affect on the
+// clients that were synchronized.
+//
+// When two event clients, A and B, are in sync they will receive events in the
+// order of arrival. If an event for both A and B is triggered, in that order,
+// it will not be possible to receive the event from B before the event from A
+// has been received.
 func Sync(c ...eventClient) error {
 	var s []rpcc.Stream
 	for _, cc := range c {


### PR DESCRIPTION
This PR implements `cdp.Sync` (and `rpcc.Sync`) for synchronizing event clients.

Closes #15.

#### Todo

- [x] Fix documentation
- [x] Clear all pending messages from Stream buffer on merge
- [x] Consider: Stream closes, what happens
    - ~~Related: Individual or combined context?~~
    - **Solution**: If a Stream closes or context is cancelled, it will not affect the other synced stream, the now closed stream will be removed from the sync.
- [x] Consider: Undo ("unsync" feature)
    - **Solution**: We do not support `unsync`, event clients should instead be abandoned when synchronization is no longer wanted.