### PR TITLE
Replace int enums with string enums

### DIFF
--- a/protocol/accessibility/types.go
+++ b/protocol/accessibility/types.go
@@ -4,8 +4,6 @@ package accessibility
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 
 	"github.com/mafredri/cdp/protocol/dom"
 )
@@ -14,287 +12,97 @@ import (
 type AXNodeID string
 
 // AXValueType Enum of possible property types.
-type AXValueType int
+type AXValueType string
 
 // AXValueType as enums.
 const (
-	AXValueTypeNotSet AXValueType = iota
-	AXValueTypeBoolean
-	AXValueTypeTristate
-	AXValueTypeBooleanOrUndefined
-	AXValueTypeIDRef
-	AXValueTypeIdrefList
-	AXValueTypeInteger
-	AXValueTypeNode
-	AXValueTypeNodeList
-	AXValueTypeNumber
-	AXValueTypeString
-	AXValueTypeComputedString
-	AXValueTypeToken
-	AXValueTypeTokenList
-	AXValueTypeDOMRelation
-	AXValueTypeRole
-	AXValueTypeInternalRole
-	AXValueTypeValueUndefined
+	AXValueTypeNotSet             AXValueType = ""
+	AXValueTypeBoolean            AXValueType = "boolean"
+	AXValueTypeTristate           AXValueType = "tristate"
+	AXValueTypeBooleanOrUndefined AXValueType = "booleanOrUndefined"
+	AXValueTypeIDRef              AXValueType = "idref"
+	AXValueTypeIdrefList          AXValueType = "idrefList"
+	AXValueTypeInteger            AXValueType = "integer"
+	AXValueTypeNode               AXValueType = "node"
+	AXValueTypeNodeList           AXValueType = "nodeList"
+	AXValueTypeNumber             AXValueType = "number"
+	AXValueTypeString             AXValueType = "string"
+	AXValueTypeComputedString     AXValueType = "computedString"
+	AXValueTypeToken              AXValueType = "token"
+	AXValueTypeTokenList          AXValueType = "tokenList"
+	AXValueTypeDOMRelation        AXValueType = "domRelation"
+	AXValueTypeRole               AXValueType = "role"
+	AXValueTypeInternalRole       AXValueType = "internalRole"
+	AXValueTypeValueUndefined     AXValueType = "valueUndefined"
 )
 
-// Valid returns true if enum is set.
 func (e AXValueType) Valid() bool {
-	return e >= 1 && e <= 17
+	switch e {
+	case "boolean", "tristate", "booleanOrUndefined", "idref", "idrefList", "integer", "node", "nodeList", "number", "string", "computedString", "token", "tokenList", "domRelation", "role", "internalRole", "valueUndefined":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXValueType) String() string {
-	switch e {
-	case 0:
-		return "AXValueTypeNotSet"
-	case 1:
-		return "boolean"
-	case 2:
-		return "tristate"
-	case 3:
-		return "booleanOrUndefined"
-	case 4:
-		return "idref"
-	case 5:
-		return "idrefList"
-	case 6:
-		return "integer"
-	case 7:
-		return "node"
-	case 8:
-		return "nodeList"
-	case 9:
-		return "number"
-	case 10:
-		return "string"
-	case 11:
-		return "computedString"
-	case 12:
-		return "token"
-	case 13:
-		return "tokenList"
-	case 14:
-		return "domRelation"
-	case 15:
-		return "role"
-	case 16:
-		return "internalRole"
-	case 17:
-		return "valueUndefined"
-	}
-	return fmt.Sprintf("AXValueType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXValueType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXValueType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXValueType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"boolean\"":
-		*e = 1
-	case "\"tristate\"":
-		*e = 2
-	case "\"booleanOrUndefined\"":
-		*e = 3
-	case "\"idref\"":
-		*e = 4
-	case "\"idrefList\"":
-		*e = 5
-	case "\"integer\"":
-		*e = 6
-	case "\"node\"":
-		*e = 7
-	case "\"nodeList\"":
-		*e = 8
-	case "\"number\"":
-		*e = 9
-	case "\"string\"":
-		*e = 10
-	case "\"computedString\"":
-		*e = 11
-	case "\"token\"":
-		*e = 12
-	case "\"tokenList\"":
-		*e = 13
-	case "\"domRelation\"":
-		*e = 14
-	case "\"role\"":
-		*e = 15
-	case "\"internalRole\"":
-		*e = 16
-	case "\"valueUndefined\"":
-		*e = 17
-	default:
-		return fmt.Errorf("accessibility.AXValueType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXValueSourceType Enum of possible property sources.
-type AXValueSourceType int
+type AXValueSourceType string
 
 // AXValueSourceType as enums.
 const (
-	AXValueSourceTypeNotSet AXValueSourceType = iota
-	AXValueSourceTypeAttribute
-	AXValueSourceTypeImplicit
-	AXValueSourceTypeStyle
-	AXValueSourceTypeContents
-	AXValueSourceTypePlaceholder
-	AXValueSourceTypeRelatedElement
+	AXValueSourceTypeNotSet         AXValueSourceType = ""
+	AXValueSourceTypeAttribute      AXValueSourceType = "attribute"
+	AXValueSourceTypeImplicit       AXValueSourceType = "implicit"
+	AXValueSourceTypeStyle          AXValueSourceType = "style"
+	AXValueSourceTypeContents       AXValueSourceType = "contents"
+	AXValueSourceTypePlaceholder    AXValueSourceType = "placeholder"
+	AXValueSourceTypeRelatedElement AXValueSourceType = "relatedElement"
 )
 
-// Valid returns true if enum is set.
 func (e AXValueSourceType) Valid() bool {
-	return e >= 1 && e <= 6
+	switch e {
+	case "attribute", "implicit", "style", "contents", "placeholder", "relatedElement":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXValueSourceType) String() string {
-	switch e {
-	case 0:
-		return "AXValueSourceTypeNotSet"
-	case 1:
-		return "attribute"
-	case 2:
-		return "implicit"
-	case 3:
-		return "style"
-	case 4:
-		return "contents"
-	case 5:
-		return "placeholder"
-	case 6:
-		return "relatedElement"
-	}
-	return fmt.Sprintf("AXValueSourceType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXValueSourceType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXValueSourceType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXValueSourceType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"attribute\"":
-		*e = 1
-	case "\"implicit\"":
-		*e = 2
-	case "\"style\"":
-		*e = 3
-	case "\"contents\"":
-		*e = 4
-	case "\"placeholder\"":
-		*e = 5
-	case "\"relatedElement\"":
-		*e = 6
-	default:
-		return fmt.Errorf("accessibility.AXValueSourceType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXValueNativeSourceType Enum of possible native property sources (as a subtype of a particular AXValueSourceType).
-type AXValueNativeSourceType int
+type AXValueNativeSourceType string
 
 // AXValueNativeSourceType as enums.
 const (
-	AXValueNativeSourceTypeNotSet AXValueNativeSourceType = iota
-	AXValueNativeSourceTypeFigcaption
-	AXValueNativeSourceTypeLabel
-	AXValueNativeSourceTypeLabelfor
-	AXValueNativeSourceTypeLabelwrapped
-	AXValueNativeSourceTypeLegend
-	AXValueNativeSourceTypeTablecaption
-	AXValueNativeSourceTypeTitle
-	AXValueNativeSourceTypeOther
+	AXValueNativeSourceTypeNotSet       AXValueNativeSourceType = ""
+	AXValueNativeSourceTypeFigcaption   AXValueNativeSourceType = "figcaption"
+	AXValueNativeSourceTypeLabel        AXValueNativeSourceType = "label"
+	AXValueNativeSourceTypeLabelfor     AXValueNativeSourceType = "labelfor"
+	AXValueNativeSourceTypeLabelwrapped AXValueNativeSourceType = "labelwrapped"
+	AXValueNativeSourceTypeLegend       AXValueNativeSourceType = "legend"
+	AXValueNativeSourceTypeTablecaption AXValueNativeSourceType = "tablecaption"
+	AXValueNativeSourceTypeTitle        AXValueNativeSourceType = "title"
+	AXValueNativeSourceTypeOther        AXValueNativeSourceType = "other"
 )
 
-// Valid returns true if enum is set.
 func (e AXValueNativeSourceType) Valid() bool {
-	return e >= 1 && e <= 8
+	switch e {
+	case "figcaption", "label", "labelfor", "labelwrapped", "legend", "tablecaption", "title", "other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXValueNativeSourceType) String() string {
-	switch e {
-	case 0:
-		return "AXValueNativeSourceTypeNotSet"
-	case 1:
-		return "figcaption"
-	case 2:
-		return "label"
-	case 3:
-		return "labelfor"
-	case 4:
-		return "labelwrapped"
-	case 5:
-		return "legend"
-	case 6:
-		return "tablecaption"
-	case 7:
-		return "title"
-	case 8:
-		return "other"
-	}
-	return fmt.Sprintf("AXValueNativeSourceType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXValueNativeSourceType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXValueNativeSourceType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXValueNativeSourceType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"figcaption\"":
-		*e = 1
-	case "\"label\"":
-		*e = 2
-	case "\"labelfor\"":
-		*e = 3
-	case "\"labelwrapped\"":
-		*e = 4
-	case "\"legend\"":
-		*e = 5
-	case "\"tablecaption\"":
-		*e = 6
-	case "\"title\"":
-		*e = 7
-	case "\"other\"":
-		*e = 8
-	default:
-		return fmt.Errorf("accessibility.AXValueNativeSourceType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXValueSource A single source for a computed AX property.
@@ -332,393 +140,143 @@ type AXValue struct {
 }
 
 // AXGlobalStates States which apply to every AX node.
-type AXGlobalStates int
+type AXGlobalStates string
 
 // AXGlobalStates as enums.
 const (
-	AXGlobalStatesNotSet AXGlobalStates = iota
-	AXGlobalStatesBusy
-	AXGlobalStatesDisabled
-	AXGlobalStatesHidden
-	AXGlobalStatesHiddenRoot
-	AXGlobalStatesInvalid
-	AXGlobalStatesKeyshortcuts
-	AXGlobalStatesRoledescription
+	AXGlobalStatesNotSet          AXGlobalStates = ""
+	AXGlobalStatesBusy            AXGlobalStates = "busy"
+	AXGlobalStatesDisabled        AXGlobalStates = "disabled"
+	AXGlobalStatesHidden          AXGlobalStates = "hidden"
+	AXGlobalStatesHiddenRoot      AXGlobalStates = "hiddenRoot"
+	AXGlobalStatesInvalid         AXGlobalStates = "invalid"
+	AXGlobalStatesKeyshortcuts    AXGlobalStates = "keyshortcuts"
+	AXGlobalStatesRoledescription AXGlobalStates = "roledescription"
 )
 
-// Valid returns true if enum is set.
 func (e AXGlobalStates) Valid() bool {
-	return e >= 1 && e <= 7
+	switch e {
+	case "busy", "disabled", "hidden", "hiddenRoot", "invalid", "keyshortcuts", "roledescription":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXGlobalStates) String() string {
-	switch e {
-	case 0:
-		return "AXGlobalStatesNotSet"
-	case 1:
-		return "busy"
-	case 2:
-		return "disabled"
-	case 3:
-		return "hidden"
-	case 4:
-		return "hiddenRoot"
-	case 5:
-		return "invalid"
-	case 6:
-		return "keyshortcuts"
-	case 7:
-		return "roledescription"
-	}
-	return fmt.Sprintf("AXGlobalStates(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXGlobalStates) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXGlobalStates: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXGlobalStates) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"busy\"":
-		*e = 1
-	case "\"disabled\"":
-		*e = 2
-	case "\"hidden\"":
-		*e = 3
-	case "\"hiddenRoot\"":
-		*e = 4
-	case "\"invalid\"":
-		*e = 5
-	case "\"keyshortcuts\"":
-		*e = 6
-	case "\"roledescription\"":
-		*e = 7
-	default:
-		return fmt.Errorf("accessibility.AXGlobalStates: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXLiveRegionAttributes Attributes which apply to nodes in live regions.
-type AXLiveRegionAttributes int
+type AXLiveRegionAttributes string
 
 // AXLiveRegionAttributes as enums.
 const (
-	AXLiveRegionAttributesNotSet AXLiveRegionAttributes = iota
-	AXLiveRegionAttributesLive
-	AXLiveRegionAttributesAtomic
-	AXLiveRegionAttributesRelevant
-	AXLiveRegionAttributesRoot
+	AXLiveRegionAttributesNotSet   AXLiveRegionAttributes = ""
+	AXLiveRegionAttributesLive     AXLiveRegionAttributes = "live"
+	AXLiveRegionAttributesAtomic   AXLiveRegionAttributes = "atomic"
+	AXLiveRegionAttributesRelevant AXLiveRegionAttributes = "relevant"
+	AXLiveRegionAttributesRoot     AXLiveRegionAttributes = "root"
 )
 
-// Valid returns true if enum is set.
 func (e AXLiveRegionAttributes) Valid() bool {
-	return e >= 1 && e <= 4
+	switch e {
+	case "live", "atomic", "relevant", "root":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXLiveRegionAttributes) String() string {
-	switch e {
-	case 0:
-		return "AXLiveRegionAttributesNotSet"
-	case 1:
-		return "live"
-	case 2:
-		return "atomic"
-	case 3:
-		return "relevant"
-	case 4:
-		return "root"
-	}
-	return fmt.Sprintf("AXLiveRegionAttributes(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXLiveRegionAttributes) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXLiveRegionAttributes: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXLiveRegionAttributes) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"live\"":
-		*e = 1
-	case "\"atomic\"":
-		*e = 2
-	case "\"relevant\"":
-		*e = 3
-	case "\"root\"":
-		*e = 4
-	default:
-		return fmt.Errorf("accessibility.AXLiveRegionAttributes: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXWidgetAttributes Attributes which apply to widgets.
-type AXWidgetAttributes int
+type AXWidgetAttributes string
 
 // AXWidgetAttributes as enums.
 const (
-	AXWidgetAttributesNotSet AXWidgetAttributes = iota
-	AXWidgetAttributesAutocomplete
-	AXWidgetAttributesHaspopup
-	AXWidgetAttributesLevel
-	AXWidgetAttributesMultiselectable
-	AXWidgetAttributesOrientation
-	AXWidgetAttributesMultiline
-	AXWidgetAttributesReadonly
-	AXWidgetAttributesRequired
-	AXWidgetAttributesValuemin
-	AXWidgetAttributesValuemax
-	AXWidgetAttributesValuetext
+	AXWidgetAttributesNotSet          AXWidgetAttributes = ""
+	AXWidgetAttributesAutocomplete    AXWidgetAttributes = "autocomplete"
+	AXWidgetAttributesHaspopup        AXWidgetAttributes = "haspopup"
+	AXWidgetAttributesLevel           AXWidgetAttributes = "level"
+	AXWidgetAttributesMultiselectable AXWidgetAttributes = "multiselectable"
+	AXWidgetAttributesOrientation     AXWidgetAttributes = "orientation"
+	AXWidgetAttributesMultiline       AXWidgetAttributes = "multiline"
+	AXWidgetAttributesReadonly        AXWidgetAttributes = "readonly"
+	AXWidgetAttributesRequired        AXWidgetAttributes = "required"
+	AXWidgetAttributesValuemin        AXWidgetAttributes = "valuemin"
+	AXWidgetAttributesValuemax        AXWidgetAttributes = "valuemax"
+	AXWidgetAttributesValuetext       AXWidgetAttributes = "valuetext"
 )
 
-// Valid returns true if enum is set.
 func (e AXWidgetAttributes) Valid() bool {
-	return e >= 1 && e <= 11
+	switch e {
+	case "autocomplete", "haspopup", "level", "multiselectable", "orientation", "multiline", "readonly", "required", "valuemin", "valuemax", "valuetext":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXWidgetAttributes) String() string {
-	switch e {
-	case 0:
-		return "AXWidgetAttributesNotSet"
-	case 1:
-		return "autocomplete"
-	case 2:
-		return "haspopup"
-	case 3:
-		return "level"
-	case 4:
-		return "multiselectable"
-	case 5:
-		return "orientation"
-	case 6:
-		return "multiline"
-	case 7:
-		return "readonly"
-	case 8:
-		return "required"
-	case 9:
-		return "valuemin"
-	case 10:
-		return "valuemax"
-	case 11:
-		return "valuetext"
-	}
-	return fmt.Sprintf("AXWidgetAttributes(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXWidgetAttributes) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXWidgetAttributes: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXWidgetAttributes) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"autocomplete\"":
-		*e = 1
-	case "\"haspopup\"":
-		*e = 2
-	case "\"level\"":
-		*e = 3
-	case "\"multiselectable\"":
-		*e = 4
-	case "\"orientation\"":
-		*e = 5
-	case "\"multiline\"":
-		*e = 6
-	case "\"readonly\"":
-		*e = 7
-	case "\"required\"":
-		*e = 8
-	case "\"valuemin\"":
-		*e = 9
-	case "\"valuemax\"":
-		*e = 10
-	case "\"valuetext\"":
-		*e = 11
-	default:
-		return fmt.Errorf("accessibility.AXWidgetAttributes: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXWidgetStates States which apply to widgets.
-type AXWidgetStates int
+type AXWidgetStates string
 
 // AXWidgetStates as enums.
 const (
-	AXWidgetStatesNotSet AXWidgetStates = iota
-	AXWidgetStatesChecked
-	AXWidgetStatesExpanded
-	AXWidgetStatesModal
-	AXWidgetStatesPressed
-	AXWidgetStatesSelected
+	AXWidgetStatesNotSet   AXWidgetStates = ""
+	AXWidgetStatesChecked  AXWidgetStates = "checked"
+	AXWidgetStatesExpanded AXWidgetStates = "expanded"
+	AXWidgetStatesModal    AXWidgetStates = "modal"
+	AXWidgetStatesPressed  AXWidgetStates = "pressed"
+	AXWidgetStatesSelected AXWidgetStates = "selected"
 )
 
-// Valid returns true if enum is set.
 func (e AXWidgetStates) Valid() bool {
-	return e >= 1 && e <= 5
+	switch e {
+	case "checked", "expanded", "modal", "pressed", "selected":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXWidgetStates) String() string {
-	switch e {
-	case 0:
-		return "AXWidgetStatesNotSet"
-	case 1:
-		return "checked"
-	case 2:
-		return "expanded"
-	case 3:
-		return "modal"
-	case 4:
-		return "pressed"
-	case 5:
-		return "selected"
-	}
-	return fmt.Sprintf("AXWidgetStates(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXWidgetStates) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXWidgetStates: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXWidgetStates) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"checked\"":
-		*e = 1
-	case "\"expanded\"":
-		*e = 2
-	case "\"modal\"":
-		*e = 3
-	case "\"pressed\"":
-		*e = 4
-	case "\"selected\"":
-		*e = 5
-	default:
-		return fmt.Errorf("accessibility.AXWidgetStates: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXRelationshipAttributes Relationships between elements other than parent/child/sibling.
-type AXRelationshipAttributes int
+type AXRelationshipAttributes string
 
 // AXRelationshipAttributes as enums.
 const (
-	AXRelationshipAttributesNotSet AXRelationshipAttributes = iota
-	AXRelationshipAttributesActivedescendant
-	AXRelationshipAttributesControls
-	AXRelationshipAttributesDescribedby
-	AXRelationshipAttributesDetails
-	AXRelationshipAttributesErrormessage
-	AXRelationshipAttributesFlowto
-	AXRelationshipAttributesLabelledby
-	AXRelationshipAttributesOwns
+	AXRelationshipAttributesNotSet           AXRelationshipAttributes = ""
+	AXRelationshipAttributesActivedescendant AXRelationshipAttributes = "activedescendant"
+	AXRelationshipAttributesControls         AXRelationshipAttributes = "controls"
+	AXRelationshipAttributesDescribedby      AXRelationshipAttributes = "describedby"
+	AXRelationshipAttributesDetails          AXRelationshipAttributes = "details"
+	AXRelationshipAttributesErrormessage     AXRelationshipAttributes = "errormessage"
+	AXRelationshipAttributesFlowto           AXRelationshipAttributes = "flowto"
+	AXRelationshipAttributesLabelledby       AXRelationshipAttributes = "labelledby"
+	AXRelationshipAttributesOwns             AXRelationshipAttributes = "owns"
 )
 
-// Valid returns true if enum is set.
 func (e AXRelationshipAttributes) Valid() bool {
-	return e >= 1 && e <= 8
+	switch e {
+	case "activedescendant", "controls", "describedby", "details", "errormessage", "flowto", "labelledby", "owns":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AXRelationshipAttributes) String() string {
-	switch e {
-	case 0:
-		return "AXRelationshipAttributesNotSet"
-	case 1:
-		return "activedescendant"
-	case 2:
-		return "controls"
-	case 3:
-		return "describedby"
-	case 4:
-		return "details"
-	case 5:
-		return "errormessage"
-	case 6:
-		return "flowto"
-	case 7:
-		return "labelledby"
-	case 8:
-		return "owns"
-	}
-	return fmt.Sprintf("AXRelationshipAttributes(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e AXRelationshipAttributes) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("accessibility.AXRelationshipAttributes: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *AXRelationshipAttributes) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"activedescendant\"":
-		*e = 1
-	case "\"controls\"":
-		*e = 2
-	case "\"describedby\"":
-		*e = 3
-	case "\"details\"":
-		*e = 4
-	case "\"errormessage\"":
-		*e = 5
-	case "\"flowto\"":
-		*e = 6
-	case "\"labelledby\"":
-		*e = 7
-	case "\"owns\"":
-		*e = 8
-	default:
-		return fmt.Errorf("accessibility.AXRelationshipAttributes: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AXNode A node in the accessibility tree.

--- a/protocol/browser/types.go
+++ b/protocol/browser/types.go
@@ -2,76 +2,32 @@
 
 package browser
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // WindowID
 type WindowID int
 
 // WindowState The state of the browser window.
-type WindowState int
+type WindowState string
 
 // WindowState as enums.
 const (
-	WindowStateNotSet WindowState = iota
-	WindowStateNormal
-	WindowStateMinimized
-	WindowStateMaximized
-	WindowStateFullscreen
+	WindowStateNotSet     WindowState = ""
+	WindowStateNormal     WindowState = "normal"
+	WindowStateMinimized  WindowState = "minimized"
+	WindowStateMaximized  WindowState = "maximized"
+	WindowStateFullscreen WindowState = "fullscreen"
 )
 
-// Valid returns true if enum is set.
 func (e WindowState) Valid() bool {
-	return e >= 1 && e <= 4
+	switch e {
+	case "normal", "minimized", "maximized", "fullscreen":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e WindowState) String() string {
-	switch e {
-	case 0:
-		return "WindowStateNotSet"
-	case 1:
-		return "normal"
-	case 2:
-		return "minimized"
-	case 3:
-		return "maximized"
-	case 4:
-		return "fullscreen"
-	}
-	return fmt.Sprintf("WindowState(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e WindowState) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("browser.WindowState: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *WindowState) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"normal\"":
-		*e = 1
-	case "\"minimized\"":
-		*e = 2
-	case "\"maximized\"":
-		*e = 3
-	case "\"fullscreen\"":
-		*e = 4
-	default:
-		return fmt.Errorf("browser.WindowState: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // Bounds Browser window bounds information

--- a/protocol/css/types.go
+++ b/protocol/css/types.go
@@ -3,10 +3,6 @@
 package css
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/mafredri/cdp/protocol/dom"
 )
 
@@ -14,66 +10,28 @@ import (
 type StyleSheetID string
 
 // StyleSheetOrigin Stylesheet type: "injected" for stylesheets injected via extension, "user-agent" for user-agent stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding the "via inspector" rules), "regular" for regular stylesheets.
-type StyleSheetOrigin int
+type StyleSheetOrigin string
 
 // StyleSheetOrigin as enums.
 const (
-	StyleSheetOriginNotSet StyleSheetOrigin = iota
-	StyleSheetOriginInjected
-	StyleSheetOriginUserAgent
-	StyleSheetOriginInspector
-	StyleSheetOriginRegular
+	StyleSheetOriginNotSet    StyleSheetOrigin = ""
+	StyleSheetOriginInjected  StyleSheetOrigin = "injected"
+	StyleSheetOriginUserAgent StyleSheetOrigin = "user-agent"
+	StyleSheetOriginInspector StyleSheetOrigin = "inspector"
+	StyleSheetOriginRegular   StyleSheetOrigin = "regular"
 )
 
-// Valid returns true if enum is set.
 func (e StyleSheetOrigin) Valid() bool {
-	return e >= 1 && e <= 4
+	switch e {
+	case "injected", "user-agent", "inspector", "regular":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e StyleSheetOrigin) String() string {
-	switch e {
-	case 0:
-		return "StyleSheetOriginNotSet"
-	case 1:
-		return "injected"
-	case 2:
-		return "user-agent"
-	case 3:
-		return "inspector"
-	case 4:
-		return "regular"
-	}
-	return fmt.Sprintf("StyleSheetOrigin(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e StyleSheetOrigin) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("css.StyleSheetOrigin: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *StyleSheetOrigin) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"injected\"":
-		*e = 1
-	case "\"user-agent\"":
-		*e = 2
-	case "\"inspector\"":
-		*e = 3
-	case "\"regular\"":
-		*e = 4
-	default:
-		return fmt.Errorf("css.StyleSheetOrigin: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // PseudoElementMatches CSS rule collection for a single pseudo style.

--- a/protocol/dom/types.go
+++ b/protocol/dom/types.go
@@ -4,8 +4,6 @@ package dom
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 )
 
 // NodeID Unique DOM node identifier.
@@ -26,179 +24,63 @@ type BackendNode struct {
 }
 
 // PseudoType Pseudo element type.
-type PseudoType int
+type PseudoType string
 
 // PseudoType as enums.
 const (
-	PseudoTypeNotSet PseudoType = iota
-	PseudoTypeFirstLine
-	PseudoTypeFirstLetter
-	PseudoTypeBefore
-	PseudoTypeAfter
-	PseudoTypeBackdrop
-	PseudoTypeSelection
-	PseudoTypeFirstLineInherited
-	PseudoTypeScrollbar
-	PseudoTypeScrollbarThumb
-	PseudoTypeScrollbarButton
-	PseudoTypeScrollbarTrack
-	PseudoTypeScrollbarTrackPiece
-	PseudoTypeScrollbarCorner
-	PseudoTypeResizer
-	PseudoTypeInputListButton
+	PseudoTypeNotSet              PseudoType = ""
+	PseudoTypeFirstLine           PseudoType = "first-line"
+	PseudoTypeFirstLetter         PseudoType = "first-letter"
+	PseudoTypeBefore              PseudoType = "before"
+	PseudoTypeAfter               PseudoType = "after"
+	PseudoTypeBackdrop            PseudoType = "backdrop"
+	PseudoTypeSelection           PseudoType = "selection"
+	PseudoTypeFirstLineInherited  PseudoType = "first-line-inherited"
+	PseudoTypeScrollbar           PseudoType = "scrollbar"
+	PseudoTypeScrollbarThumb      PseudoType = "scrollbar-thumb"
+	PseudoTypeScrollbarButton     PseudoType = "scrollbar-button"
+	PseudoTypeScrollbarTrack      PseudoType = "scrollbar-track"
+	PseudoTypeScrollbarTrackPiece PseudoType = "scrollbar-track-piece"
+	PseudoTypeScrollbarCorner     PseudoType = "scrollbar-corner"
+	PseudoTypeResizer             PseudoType = "resizer"
+	PseudoTypeInputListButton     PseudoType = "input-list-button"
 )
 
-// Valid returns true if enum is set.
 func (e PseudoType) Valid() bool {
-	return e >= 1 && e <= 15
+	switch e {
+	case "first-line", "first-letter", "before", "after", "backdrop", "selection", "first-line-inherited", "scrollbar", "scrollbar-thumb", "scrollbar-button", "scrollbar-track", "scrollbar-track-piece", "scrollbar-corner", "resizer", "input-list-button":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e PseudoType) String() string {
-	switch e {
-	case 0:
-		return "PseudoTypeNotSet"
-	case 1:
-		return "first-line"
-	case 2:
-		return "first-letter"
-	case 3:
-		return "before"
-	case 4:
-		return "after"
-	case 5:
-		return "backdrop"
-	case 6:
-		return "selection"
-	case 7:
-		return "first-line-inherited"
-	case 8:
-		return "scrollbar"
-	case 9:
-		return "scrollbar-thumb"
-	case 10:
-		return "scrollbar-button"
-	case 11:
-		return "scrollbar-track"
-	case 12:
-		return "scrollbar-track-piece"
-	case 13:
-		return "scrollbar-corner"
-	case 14:
-		return "resizer"
-	case 15:
-		return "input-list-button"
-	}
-	return fmt.Sprintf("PseudoType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e PseudoType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("dom.PseudoType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *PseudoType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"first-line\"":
-		*e = 1
-	case "\"first-letter\"":
-		*e = 2
-	case "\"before\"":
-		*e = 3
-	case "\"after\"":
-		*e = 4
-	case "\"backdrop\"":
-		*e = 5
-	case "\"selection\"":
-		*e = 6
-	case "\"first-line-inherited\"":
-		*e = 7
-	case "\"scrollbar\"":
-		*e = 8
-	case "\"scrollbar-thumb\"":
-		*e = 9
-	case "\"scrollbar-button\"":
-		*e = 10
-	case "\"scrollbar-track\"":
-		*e = 11
-	case "\"scrollbar-track-piece\"":
-		*e = 12
-	case "\"scrollbar-corner\"":
-		*e = 13
-	case "\"resizer\"":
-		*e = 14
-	case "\"input-list-button\"":
-		*e = 15
-	default:
-		return fmt.Errorf("dom.PseudoType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // ShadowRootType Shadow root type.
-type ShadowRootType int
+type ShadowRootType string
 
 // ShadowRootType as enums.
 const (
-	ShadowRootTypeNotSet ShadowRootType = iota
-	ShadowRootTypeUserAgent
-	ShadowRootTypeOpen
-	ShadowRootTypeClosed
+	ShadowRootTypeNotSet    ShadowRootType = ""
+	ShadowRootTypeUserAgent ShadowRootType = "user-agent"
+	ShadowRootTypeOpen      ShadowRootType = "open"
+	ShadowRootTypeClosed    ShadowRootType = "closed"
 )
 
-// Valid returns true if enum is set.
 func (e ShadowRootType) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "user-agent", "open", "closed":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e ShadowRootType) String() string {
-	switch e {
-	case 0:
-		return "ShadowRootTypeNotSet"
-	case 1:
-		return "user-agent"
-	case 2:
-		return "open"
-	case 3:
-		return "closed"
-	}
-	return fmt.Sprintf("ShadowRootType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e ShadowRootType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("dom.ShadowRootType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *ShadowRootType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"user-agent\"":
-		*e = 1
-	case "\"open\"":
-		*e = 2
-	case "\"closed\"":
-		*e = 3
-	default:
-		return fmt.Errorf("dom.ShadowRootType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // RGBA A structure holding an RGBA color.

--- a/protocol/domdebugger/types.go
+++ b/protocol/domdebugger/types.go
@@ -3,70 +3,32 @@
 package domdebugger
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/mafredri/cdp/protocol/dom"
 	"github.com/mafredri/cdp/protocol/runtime"
 )
 
 // DOMBreakpointType DOM breakpoint type.
-type DOMBreakpointType int
+type DOMBreakpointType string
 
 // DOMBreakpointType as enums.
 const (
-	DOMBreakpointTypeNotSet DOMBreakpointType = iota
-	DOMBreakpointTypeSubtreeModified
-	DOMBreakpointTypeAttributeModified
-	DOMBreakpointTypeNodeRemoved
+	DOMBreakpointTypeNotSet            DOMBreakpointType = ""
+	DOMBreakpointTypeSubtreeModified   DOMBreakpointType = "subtree-modified"
+	DOMBreakpointTypeAttributeModified DOMBreakpointType = "attribute-modified"
+	DOMBreakpointTypeNodeRemoved       DOMBreakpointType = "node-removed"
 )
 
-// Valid returns true if enum is set.
 func (e DOMBreakpointType) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "subtree-modified", "attribute-modified", "node-removed":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e DOMBreakpointType) String() string {
-	switch e {
-	case 0:
-		return "DOMBreakpointTypeNotSet"
-	case 1:
-		return "subtree-modified"
-	case 2:
-		return "attribute-modified"
-	case 3:
-		return "node-removed"
-	}
-	return fmt.Sprintf("DOMBreakpointType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e DOMBreakpointType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("domdebugger.DOMBreakpointType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *DOMBreakpointType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"subtree-modified\"":
-		*e = 1
-	case "\"attribute-modified\"":
-		*e = 2
-	case "\"node-removed\"":
-		*e = 3
-	default:
-		return fmt.Errorf("domdebugger.DOMBreakpointType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // EventListener Object event listener.

--- a/protocol/emulation/types.go
+++ b/protocol/emulation/types.go
@@ -2,12 +2,6 @@
 
 package emulation
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // ScreenOrientation Screen orientation.
 type ScreenOrientation struct {
 	// Type Orientation type.
@@ -20,59 +14,25 @@ type ScreenOrientation struct {
 // VirtualTimePolicy advance: If the scheduler runs out of immediate work, the virtual time base may fast forward to allow the next delayed task (if any) to run; pause: The virtual time base may not advance; pauseIfNetworkFetchesPending: The virtual time base may not advance if there are any pending resource fetches.
 //
 // Note: This type is experimental.
-type VirtualTimePolicy int
+type VirtualTimePolicy string
 
 // VirtualTimePolicy as enums.
 const (
-	VirtualTimePolicyNotSet VirtualTimePolicy = iota
-	VirtualTimePolicyAdvance
-	VirtualTimePolicyPause
-	VirtualTimePolicyPauseIfNetworkFetchesPending
+	VirtualTimePolicyNotSet                       VirtualTimePolicy = ""
+	VirtualTimePolicyAdvance                      VirtualTimePolicy = "advance"
+	VirtualTimePolicyPause                        VirtualTimePolicy = "pause"
+	VirtualTimePolicyPauseIfNetworkFetchesPending VirtualTimePolicy = "pauseIfNetworkFetchesPending"
 )
 
-// Valid returns true if enum is set.
 func (e VirtualTimePolicy) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "advance", "pause", "pauseIfNetworkFetchesPending":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e VirtualTimePolicy) String() string {
-	switch e {
-	case 0:
-		return "VirtualTimePolicyNotSet"
-	case 1:
-		return "advance"
-	case 2:
-		return "pause"
-	case 3:
-		return "pauseIfNetworkFetchesPending"
-	}
-	return fmt.Sprintf("VirtualTimePolicy(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e VirtualTimePolicy) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("emulation.VirtualTimePolicy: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *VirtualTimePolicy) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"advance\"":
-		*e = 1
-	case "\"pause\"":
-		*e = 2
-	case "\"pauseIfNetworkFetchesPending\"":
-		*e = 3
-	default:
-		return fmt.Errorf("emulation.VirtualTimePolicy: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }

--- a/protocol/input/types.go
+++ b/protocol/input/types.go
@@ -5,7 +5,6 @@ package input
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -25,61 +24,27 @@ type TouchPoint struct {
 // GestureSourceType
 //
 // Note: This type is experimental.
-type GestureSourceType int
+type GestureSourceType string
 
 // GestureSourceType as enums.
 const (
-	GestureSourceTypeNotSet GestureSourceType = iota
-	GestureSourceTypeDefault
-	GestureSourceTypeTouch
-	GestureSourceTypeMouse
+	GestureSourceTypeNotSet  GestureSourceType = ""
+	GestureSourceTypeDefault GestureSourceType = "default"
+	GestureSourceTypeTouch   GestureSourceType = "touch"
+	GestureSourceTypeMouse   GestureSourceType = "mouse"
 )
 
-// Valid returns true if enum is set.
 func (e GestureSourceType) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "default", "touch", "mouse":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e GestureSourceType) String() string {
-	switch e {
-	case 0:
-		return "GestureSourceTypeNotSet"
-	case 1:
-		return "default"
-	case 2:
-		return "touch"
-	case 3:
-		return "mouse"
-	}
-	return fmt.Sprintf("GestureSourceType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e GestureSourceType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("input.GestureSourceType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *GestureSourceType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"default\"":
-		*e = 1
-	case "\"touch\"":
-		*e = 2
-	case "\"mouse\"":
-		*e = 3
-	default:
-		return fmt.Errorf("input.GestureSourceType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // TimeSinceEpoch UTC time in seconds, counted from January 1, 1970.

--- a/protocol/internal/page19.go
+++ b/protocol/internal/page19.go
@@ -4,102 +4,22 @@
 
 package internal
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // PageResourceType Resource type as it was perceived by the rendering engine.
 //
 // This type cannot be used directly. Use page.ResourceType instead.
-type PageResourceType int
+type PageResourceType string
 
-// Valid returns true if enum is set.
 func (e PageResourceType) Valid() bool {
-	return e >= 1 && e <= 13
+	switch e {
+	case "Document", "Stylesheet", "Image", "Media", "Font", "Script", "TextTrack", "XHR", "Fetch", "EventSource", "WebSocket", "Manifest", "Other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e PageResourceType) String() string {
-	switch e {
-	case 0:
-		return "PageResourceTypeNotSet"
-	case 1:
-		return "Document"
-	case 2:
-		return "Stylesheet"
-	case 3:
-		return "Image"
-	case 4:
-		return "Media"
-	case 5:
-		return "Font"
-	case 6:
-		return "Script"
-	case 7:
-		return "TextTrack"
-	case 8:
-		return "XHR"
-	case 9:
-		return "Fetch"
-	case 10:
-		return "EventSource"
-	case 11:
-		return "WebSocket"
-	case 12:
-		return "Manifest"
-	case 13:
-		return "Other"
-	}
-	return fmt.Sprintf("PageResourceType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e PageResourceType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("internal.PageResourceType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *PageResourceType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"Document\"":
-		*e = 1
-	case "\"Stylesheet\"":
-		*e = 2
-	case "\"Image\"":
-		*e = 3
-	case "\"Media\"":
-		*e = 4
-	case "\"Font\"":
-		*e = 5
-	case "\"Script\"":
-		*e = 6
-	case "\"TextTrack\"":
-		*e = 7
-	case "\"XHR\"":
-		*e = 8
-	case "\"Fetch\"":
-		*e = 9
-	case "\"EventSource\"":
-		*e = 10
-	case "\"WebSocket\"":
-		*e = 11
-	case "\"Manifest\"":
-		*e = 12
-	case "\"Other\"":
-		*e = 13
-	default:
-		return fmt.Errorf("internal.PageResourceType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // PageFrameID Unique frame identifier.

--- a/protocol/memory/types.go
+++ b/protocol/memory/types.go
@@ -2,61 +2,25 @@
 
 package memory
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // PressureLevel Memory pressure level.
-type PressureLevel int
+type PressureLevel string
 
 // PressureLevel as enums.
 const (
-	PressureLevelNotSet PressureLevel = iota
-	PressureLevelModerate
-	PressureLevelCritical
+	PressureLevelNotSet   PressureLevel = ""
+	PressureLevelModerate PressureLevel = "moderate"
+	PressureLevelCritical PressureLevel = "critical"
 )
 
-// Valid returns true if enum is set.
 func (e PressureLevel) Valid() bool {
-	return e >= 1 && e <= 2
+	switch e {
+	case "moderate", "critical":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e PressureLevel) String() string {
-	switch e {
-	case 0:
-		return "PressureLevelNotSet"
-	case 1:
-		return "moderate"
-	case 2:
-		return "critical"
-	}
-	return fmt.Sprintf("PressureLevel(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e PressureLevel) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("memory.PressureLevel: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *PressureLevel) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"moderate\"":
-		*e = 1
-	case "\"critical\"":
-		*e = 2
-	default:
-		return fmt.Errorf("memory.PressureLevel: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }

--- a/protocol/network/types.go
+++ b/protocol/network/types.go
@@ -5,7 +5,6 @@ package network
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/mafredri/cdp/protocol/runtime"
@@ -22,106 +21,36 @@ type RequestID string
 type InterceptionID string
 
 // ErrorReason Network level fetch failure reason.
-type ErrorReason int
+type ErrorReason string
 
 // ErrorReason as enums.
 const (
-	ErrorReasonNotSet ErrorReason = iota
-	ErrorReasonFailed
-	ErrorReasonAborted
-	ErrorReasonTimedOut
-	ErrorReasonAccessDenied
-	ErrorReasonConnectionClosed
-	ErrorReasonConnectionReset
-	ErrorReasonConnectionRefused
-	ErrorReasonConnectionAborted
-	ErrorReasonConnectionFailed
-	ErrorReasonNameNotResolved
-	ErrorReasonInternetDisconnected
-	ErrorReasonAddressUnreachable
+	ErrorReasonNotSet               ErrorReason = ""
+	ErrorReasonFailed               ErrorReason = "Failed"
+	ErrorReasonAborted              ErrorReason = "Aborted"
+	ErrorReasonTimedOut             ErrorReason = "TimedOut"
+	ErrorReasonAccessDenied         ErrorReason = "AccessDenied"
+	ErrorReasonConnectionClosed     ErrorReason = "ConnectionClosed"
+	ErrorReasonConnectionReset      ErrorReason = "ConnectionReset"
+	ErrorReasonConnectionRefused    ErrorReason = "ConnectionRefused"
+	ErrorReasonConnectionAborted    ErrorReason = "ConnectionAborted"
+	ErrorReasonConnectionFailed     ErrorReason = "ConnectionFailed"
+	ErrorReasonNameNotResolved      ErrorReason = "NameNotResolved"
+	ErrorReasonInternetDisconnected ErrorReason = "InternetDisconnected"
+	ErrorReasonAddressUnreachable   ErrorReason = "AddressUnreachable"
 )
 
-// Valid returns true if enum is set.
 func (e ErrorReason) Valid() bool {
-	return e >= 1 && e <= 12
+	switch e {
+	case "Failed", "Aborted", "TimedOut", "AccessDenied", "ConnectionClosed", "ConnectionReset", "ConnectionRefused", "ConnectionAborted", "ConnectionFailed", "NameNotResolved", "InternetDisconnected", "AddressUnreachable":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e ErrorReason) String() string {
-	switch e {
-	case 0:
-		return "ErrorReasonNotSet"
-	case 1:
-		return "Failed"
-	case 2:
-		return "Aborted"
-	case 3:
-		return "TimedOut"
-	case 4:
-		return "AccessDenied"
-	case 5:
-		return "ConnectionClosed"
-	case 6:
-		return "ConnectionReset"
-	case 7:
-		return "ConnectionRefused"
-	case 8:
-		return "ConnectionAborted"
-	case 9:
-		return "ConnectionFailed"
-	case 10:
-		return "NameNotResolved"
-	case 11:
-		return "InternetDisconnected"
-	case 12:
-		return "AddressUnreachable"
-	}
-	return fmt.Sprintf("ErrorReason(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e ErrorReason) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("network.ErrorReason: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *ErrorReason) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"Failed\"":
-		*e = 1
-	case "\"Aborted\"":
-		*e = 2
-	case "\"TimedOut\"":
-		*e = 3
-	case "\"AccessDenied\"":
-		*e = 4
-	case "\"ConnectionClosed\"":
-		*e = 5
-	case "\"ConnectionReset\"":
-		*e = 6
-	case "\"ConnectionRefused\"":
-		*e = 7
-	case "\"ConnectionAborted\"":
-		*e = 8
-	case "\"ConnectionFailed\"":
-		*e = 9
-	case "\"NameNotResolved\"":
-		*e = 10
-	case "\"InternetDisconnected\"":
-		*e = 11
-	case "\"AddressUnreachable\"":
-		*e = 12
-	default:
-		return fmt.Errorf("network.ErrorReason: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // TimeSinceEpoch UTC time in seconds, counted from January 1, 1970.
@@ -232,144 +161,56 @@ var _ json.Marshaler = (*Headers)(nil)
 var _ json.Unmarshaler = (*Headers)(nil)
 
 // ConnectionType Loading priority of a resource request.
-type ConnectionType int
+type ConnectionType string
 
 // ConnectionType as enums.
 const (
-	ConnectionTypeNotSet ConnectionType = iota
-	ConnectionTypeNone
-	ConnectionTypeCellular2g
-	ConnectionTypeCellular3g
-	ConnectionTypeCellular4g
-	ConnectionTypeBluetooth
-	ConnectionTypeEthernet
-	ConnectionTypeWifi
-	ConnectionTypeWimax
-	ConnectionTypeOther
+	ConnectionTypeNotSet     ConnectionType = ""
+	ConnectionTypeNone       ConnectionType = "none"
+	ConnectionTypeCellular2g ConnectionType = "cellular2g"
+	ConnectionTypeCellular3g ConnectionType = "cellular3g"
+	ConnectionTypeCellular4g ConnectionType = "cellular4g"
+	ConnectionTypeBluetooth  ConnectionType = "bluetooth"
+	ConnectionTypeEthernet   ConnectionType = "ethernet"
+	ConnectionTypeWifi       ConnectionType = "wifi"
+	ConnectionTypeWimax      ConnectionType = "wimax"
+	ConnectionTypeOther      ConnectionType = "other"
 )
 
-// Valid returns true if enum is set.
 func (e ConnectionType) Valid() bool {
-	return e >= 1 && e <= 9
+	switch e {
+	case "none", "cellular2g", "cellular3g", "cellular4g", "bluetooth", "ethernet", "wifi", "wimax", "other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e ConnectionType) String() string {
-	switch e {
-	case 0:
-		return "ConnectionTypeNotSet"
-	case 1:
-		return "none"
-	case 2:
-		return "cellular2g"
-	case 3:
-		return "cellular3g"
-	case 4:
-		return "cellular4g"
-	case 5:
-		return "bluetooth"
-	case 6:
-		return "ethernet"
-	case 7:
-		return "wifi"
-	case 8:
-		return "wimax"
-	case 9:
-		return "other"
-	}
-	return fmt.Sprintf("ConnectionType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e ConnectionType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("network.ConnectionType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *ConnectionType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"none\"":
-		*e = 1
-	case "\"cellular2g\"":
-		*e = 2
-	case "\"cellular3g\"":
-		*e = 3
-	case "\"cellular4g\"":
-		*e = 4
-	case "\"bluetooth\"":
-		*e = 5
-	case "\"ethernet\"":
-		*e = 6
-	case "\"wifi\"":
-		*e = 7
-	case "\"wimax\"":
-		*e = 8
-	case "\"other\"":
-		*e = 9
-	default:
-		return fmt.Errorf("network.ConnectionType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // CookieSameSite Represents the cookie's 'SameSite' status: https://tools.ietf.org/html/draft-west-first-party-cookies
-type CookieSameSite int
+type CookieSameSite string
 
 // CookieSameSite as enums.
 const (
-	CookieSameSiteNotSet CookieSameSite = iota
-	CookieSameSiteStrict
-	CookieSameSiteLax
+	CookieSameSiteNotSet CookieSameSite = ""
+	CookieSameSiteStrict CookieSameSite = "Strict"
+	CookieSameSiteLax    CookieSameSite = "Lax"
 )
 
-// Valid returns true if enum is set.
 func (e CookieSameSite) Valid() bool {
-	return e >= 1 && e <= 2
+	switch e {
+	case "Strict", "Lax":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e CookieSameSite) String() string {
-	switch e {
-	case 0:
-		return "CookieSameSiteNotSet"
-	case 1:
-		return "Strict"
-	case 2:
-		return "Lax"
-	}
-	return fmt.Sprintf("CookieSameSite(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e CookieSameSite) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("network.CookieSameSite: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *CookieSameSite) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"Strict\"":
-		*e = 1
-	case "\"Lax\"":
-		*e = 2
-	default:
-		return fmt.Errorf("network.CookieSameSite: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // ResourceTiming Timing information for the request.
@@ -405,71 +246,29 @@ type ResourceTiming struct {
 }
 
 // ResourcePriority Loading priority of a resource request.
-type ResourcePriority int
+type ResourcePriority string
 
 // ResourcePriority as enums.
 const (
-	ResourcePriorityNotSet ResourcePriority = iota
-	ResourcePriorityVeryLow
-	ResourcePriorityLow
-	ResourcePriorityMedium
-	ResourcePriorityHigh
-	ResourcePriorityVeryHigh
+	ResourcePriorityNotSet   ResourcePriority = ""
+	ResourcePriorityVeryLow  ResourcePriority = "VeryLow"
+	ResourcePriorityLow      ResourcePriority = "Low"
+	ResourcePriorityMedium   ResourcePriority = "Medium"
+	ResourcePriorityHigh     ResourcePriority = "High"
+	ResourcePriorityVeryHigh ResourcePriority = "VeryHigh"
 )
 
-// Valid returns true if enum is set.
 func (e ResourcePriority) Valid() bool {
-	return e >= 1 && e <= 5
+	switch e {
+	case "VeryLow", "Low", "Medium", "High", "VeryHigh":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e ResourcePriority) String() string {
-	switch e {
-	case 0:
-		return "ResourcePriorityNotSet"
-	case 1:
-		return "VeryLow"
-	case 2:
-		return "Low"
-	case 3:
-		return "Medium"
-	case 4:
-		return "High"
-	case 5:
-		return "VeryHigh"
-	}
-	return fmt.Sprintf("ResourcePriority(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e ResourcePriority) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("network.ResourcePriority: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *ResourcePriority) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"VeryLow\"":
-		*e = 1
-	case "\"Low\"":
-		*e = 2
-	case "\"Medium\"":
-		*e = 3
-	case "\"High\"":
-		*e = 4
-	case "\"VeryHigh\"":
-		*e = 5
-	default:
-		return fmt.Errorf("network.ResourcePriority: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // Request HTTP request data.
@@ -518,76 +317,30 @@ type SecurityDetails struct {
 // BlockedReason The reason why request was blocked.
 //
 // Note: This type is experimental.
-type BlockedReason int
+type BlockedReason string
 
 // BlockedReason as enums.
 const (
-	BlockedReasonNotSet BlockedReason = iota
-	BlockedReasonCsp
-	BlockedReasonMixedContent
-	BlockedReasonOrigin
-	BlockedReasonInspector
-	BlockedReasonSubresourceFilter
-	BlockedReasonOther
+	BlockedReasonNotSet            BlockedReason = ""
+	BlockedReasonCsp               BlockedReason = "csp"
+	BlockedReasonMixedContent      BlockedReason = "mixed-content"
+	BlockedReasonOrigin            BlockedReason = "origin"
+	BlockedReasonInspector         BlockedReason = "inspector"
+	BlockedReasonSubresourceFilter BlockedReason = "subresource-filter"
+	BlockedReasonOther             BlockedReason = "other"
 )
 
-// Valid returns true if enum is set.
 func (e BlockedReason) Valid() bool {
-	return e >= 1 && e <= 6
+	switch e {
+	case "csp", "mixed-content", "origin", "inspector", "subresource-filter", "other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e BlockedReason) String() string {
-	switch e {
-	case 0:
-		return "BlockedReasonNotSet"
-	case 1:
-		return "csp"
-	case 2:
-		return "mixed-content"
-	case 3:
-		return "origin"
-	case 4:
-		return "inspector"
-	case 5:
-		return "subresource-filter"
-	case 6:
-		return "other"
-	}
-	return fmt.Sprintf("BlockedReason(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e BlockedReason) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("network.BlockedReason: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *BlockedReason) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"csp\"":
-		*e = 1
-	case "\"mixed-content\"":
-		*e = 2
-	case "\"origin\"":
-		*e = 3
-	case "\"inspector\"":
-		*e = 4
-	case "\"subresource-filter\"":
-		*e = 5
-	case "\"other\"":
-		*e = 6
-	default:
-		return fmt.Errorf("network.BlockedReason: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // Response HTTP response data.

--- a/protocol/overlay/types.go
+++ b/protocol/overlay/types.go
@@ -3,10 +3,6 @@
 package overlay
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/mafredri/cdp/protocol/dom"
 )
 
@@ -28,59 +24,25 @@ type HighlightConfig struct {
 }
 
 // InspectMode
-type InspectMode int
+type InspectMode string
 
 // InspectMode as enums.
 const (
-	InspectModeNotSet InspectMode = iota
-	InspectModeSearchForNode
-	InspectModeSearchForUAShadowDOM
-	InspectModeNone
+	InspectModeNotSet               InspectMode = ""
+	InspectModeSearchForNode        InspectMode = "searchForNode"
+	InspectModeSearchForUAShadowDOM InspectMode = "searchForUAShadowDOM"
+	InspectModeNone                 InspectMode = "none"
 )
 
-// Valid returns true if enum is set.
 func (e InspectMode) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "searchForNode", "searchForUAShadowDOM", "none":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e InspectMode) String() string {
-	switch e {
-	case 0:
-		return "InspectModeNotSet"
-	case 1:
-		return "searchForNode"
-	case 2:
-		return "searchForUAShadowDOM"
-	case 3:
-		return "none"
-	}
-	return fmt.Sprintf("InspectMode(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e InspectMode) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("overlay.InspectMode: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *InspectMode) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"searchForNode\"":
-		*e = 1
-	case "\"searchForUAShadowDOM\"":
-		*e = 2
-	case "\"none\"":
-		*e = 3
-	default:
-		return fmt.Errorf("overlay.InspectMode: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }

--- a/protocol/page/types.go
+++ b/protocol/page/types.go
@@ -3,10 +3,6 @@
 package page
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/mafredri/cdp/protocol/network"
 )
 
@@ -27,106 +23,36 @@ type ScriptIdentifier string
 // TransitionType Transition type.
 //
 // Note: This type is experimental.
-type TransitionType int
+type TransitionType string
 
 // TransitionType as enums.
 const (
-	TransitionTypeNotSet TransitionType = iota
-	TransitionTypeLink
-	TransitionTypeTyped
-	TransitionTypeAutoBookmark
-	TransitionTypeAutoSubframe
-	TransitionTypeManualSubframe
-	TransitionTypeGenerated
-	TransitionTypeAutoToplevel
-	TransitionTypeFormSubmit
-	TransitionTypeReload
-	TransitionTypeKeyword
-	TransitionTypeKeywordGenerated
-	TransitionTypeOther
+	TransitionTypeNotSet           TransitionType = ""
+	TransitionTypeLink             TransitionType = "link"
+	TransitionTypeTyped            TransitionType = "typed"
+	TransitionTypeAutoBookmark     TransitionType = "auto_bookmark"
+	TransitionTypeAutoSubframe     TransitionType = "auto_subframe"
+	TransitionTypeManualSubframe   TransitionType = "manual_subframe"
+	TransitionTypeGenerated        TransitionType = "generated"
+	TransitionTypeAutoToplevel     TransitionType = "auto_toplevel"
+	TransitionTypeFormSubmit       TransitionType = "form_submit"
+	TransitionTypeReload           TransitionType = "reload"
+	TransitionTypeKeyword          TransitionType = "keyword"
+	TransitionTypeKeywordGenerated TransitionType = "keyword_generated"
+	TransitionTypeOther            TransitionType = "other"
 )
 
-// Valid returns true if enum is set.
 func (e TransitionType) Valid() bool {
-	return e >= 1 && e <= 12
+	switch e {
+	case "link", "typed", "auto_bookmark", "auto_subframe", "manual_subframe", "generated", "auto_toplevel", "form_submit", "reload", "keyword", "keyword_generated", "other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e TransitionType) String() string {
-	switch e {
-	case 0:
-		return "TransitionTypeNotSet"
-	case 1:
-		return "link"
-	case 2:
-		return "typed"
-	case 3:
-		return "auto_bookmark"
-	case 4:
-		return "auto_subframe"
-	case 5:
-		return "manual_subframe"
-	case 6:
-		return "generated"
-	case 7:
-		return "auto_toplevel"
-	case 8:
-		return "form_submit"
-	case 9:
-		return "reload"
-	case 10:
-		return "keyword"
-	case 11:
-		return "keyword_generated"
-	case 12:
-		return "other"
-	}
-	return fmt.Sprintf("TransitionType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e TransitionType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("page.TransitionType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *TransitionType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"link\"":
-		*e = 1
-	case "\"typed\"":
-		*e = 2
-	case "\"auto_bookmark\"":
-		*e = 3
-	case "\"auto_subframe\"":
-		*e = 4
-	case "\"manual_subframe\"":
-		*e = 5
-	case "\"generated\"":
-		*e = 6
-	case "\"auto_toplevel\"":
-		*e = 7
-	case "\"form_submit\"":
-		*e = 8
-	case "\"reload\"":
-		*e = 9
-	case "\"keyword\"":
-		*e = 10
-	case "\"keyword_generated\"":
-		*e = 11
-	case "\"other\"":
-		*e = 12
-	default:
-		return fmt.Errorf("page.TransitionType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // NavigationEntry Navigation history entry.
@@ -177,66 +103,28 @@ type ScreencastFrameMetadata struct {
 // DialogType Javascript dialog type.
 //
 // Note: This type is experimental.
-type DialogType int
+type DialogType string
 
 // DialogType as enums.
 const (
-	DialogTypeNotSet DialogType = iota
-	DialogTypeAlert
-	DialogTypeConfirm
-	DialogTypePrompt
-	DialogTypeBeforeunload
+	DialogTypeNotSet       DialogType = ""
+	DialogTypeAlert        DialogType = "alert"
+	DialogTypeConfirm      DialogType = "confirm"
+	DialogTypePrompt       DialogType = "prompt"
+	DialogTypeBeforeunload DialogType = "beforeunload"
 )
 
-// Valid returns true if enum is set.
 func (e DialogType) Valid() bool {
-	return e >= 1 && e <= 4
+	switch e {
+	case "alert", "confirm", "prompt", "beforeunload":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e DialogType) String() string {
-	switch e {
-	case 0:
-		return "DialogTypeNotSet"
-	case 1:
-		return "alert"
-	case 2:
-		return "confirm"
-	case 3:
-		return "prompt"
-	case 4:
-		return "beforeunload"
-	}
-	return fmt.Sprintf("DialogType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e DialogType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("page.DialogType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *DialogType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"alert\"":
-		*e = 1
-	case "\"confirm\"":
-		*e = 2
-	case "\"prompt\"":
-		*e = 3
-	case "\"beforeunload\"":
-		*e = 4
-	default:
-		return fmt.Errorf("page.DialogType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // AppManifestError Error while paring app manifest.
@@ -252,61 +140,27 @@ type AppManifestError struct {
 // NavigationResponse Proceed: allow the navigation; Cancel: cancel the navigation; CancelAndIgnore: cancels the navigation and makes the requester of the navigation acts like the request was never made.
 //
 // Note: This type is experimental.
-type NavigationResponse int
+type NavigationResponse string
 
 // NavigationResponse as enums.
 const (
-	NavigationResponseNotSet NavigationResponse = iota
-	NavigationResponseProceed
-	NavigationResponseCancel
-	NavigationResponseCancelAndIgnore
+	NavigationResponseNotSet          NavigationResponse = ""
+	NavigationResponseProceed         NavigationResponse = "Proceed"
+	NavigationResponseCancel          NavigationResponse = "Cancel"
+	NavigationResponseCancelAndIgnore NavigationResponse = "CancelAndIgnore"
 )
 
-// Valid returns true if enum is set.
 func (e NavigationResponse) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "Proceed", "Cancel", "CancelAndIgnore":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e NavigationResponse) String() string {
-	switch e {
-	case 0:
-		return "NavigationResponseNotSet"
-	case 1:
-		return "Proceed"
-	case 2:
-		return "Cancel"
-	case 3:
-		return "CancelAndIgnore"
-	}
-	return fmt.Sprintf("NavigationResponse(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e NavigationResponse) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("page.NavigationResponse: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *NavigationResponse) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"Proceed\"":
-		*e = 1
-	case "\"Cancel\"":
-		*e = 2
-	case "\"CancelAndIgnore\"":
-		*e = 3
-	default:
-		return fmt.Errorf("page.NavigationResponse: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // LayoutViewport Layout viewport position and dimensions.

--- a/protocol/page/types18.go
+++ b/protocol/page/types18.go
@@ -10,24 +10,24 @@ import (
 )
 
 // ResourceType Resource type as it was perceived by the rendering engine.
-//type ResourceType int
+//type ResourceType string
 
 // ResourceType as enums.
 const (
-	ResourceTypeNotSet protocol.PageResourceType = iota
-	ResourceTypeDocument
-	ResourceTypeStylesheet
-	ResourceTypeImage
-	ResourceTypeMedia
-	ResourceTypeFont
-	ResourceTypeScript
-	ResourceTypeTextTrack
-	ResourceTypeXHR
-	ResourceTypeFetch
-	ResourceTypeEventSource
-	ResourceTypeWebSocket
-	ResourceTypeManifest
-	ResourceTypeOther
+	ResourceTypeNotSet      protocol.PageResourceType = ""
+	ResourceTypeDocument    protocol.PageResourceType = "Document"
+	ResourceTypeStylesheet  protocol.PageResourceType = "Stylesheet"
+	ResourceTypeImage       protocol.PageResourceType = "Image"
+	ResourceTypeMedia       protocol.PageResourceType = "Media"
+	ResourceTypeFont        protocol.PageResourceType = "Font"
+	ResourceTypeScript      protocol.PageResourceType = "Script"
+	ResourceTypeTextTrack   protocol.PageResourceType = "TextTrack"
+	ResourceTypeXHR         protocol.PageResourceType = "XHR"
+	ResourceTypeFetch       protocol.PageResourceType = "Fetch"
+	ResourceTypeEventSource protocol.PageResourceType = "EventSource"
+	ResourceTypeWebSocket   protocol.PageResourceType = "WebSocket"
+	ResourceTypeManifest    protocol.PageResourceType = "Manifest"
+	ResourceTypeOther       protocol.PageResourceType = "Other"
 )
 
 // FrameID Unique frame identifier.

--- a/protocol/page/types19.go
+++ b/protocol/page/types19.go
@@ -15,24 +15,24 @@ import (
 type ResourceType = internal.PageResourceType
 
 // ResourceType Resource type as it was perceived by the rendering engine.
-//type ResourceType int
+//type ResourceType string
 
 // ResourceType as enums.
 const (
-	ResourceTypeNotSet ResourceType = iota
-	ResourceTypeDocument
-	ResourceTypeStylesheet
-	ResourceTypeImage
-	ResourceTypeMedia
-	ResourceTypeFont
-	ResourceTypeScript
-	ResourceTypeTextTrack
-	ResourceTypeXHR
-	ResourceTypeFetch
-	ResourceTypeEventSource
-	ResourceTypeWebSocket
-	ResourceTypeManifest
-	ResourceTypeOther
+	ResourceTypeNotSet      ResourceType = ""
+	ResourceTypeDocument    ResourceType = "Document"
+	ResourceTypeStylesheet  ResourceType = "Stylesheet"
+	ResourceTypeImage       ResourceType = "Image"
+	ResourceTypeMedia       ResourceType = "Media"
+	ResourceTypeFont        ResourceType = "Font"
+	ResourceTypeScript      ResourceType = "Script"
+	ResourceTypeTextTrack   ResourceType = "TextTrack"
+	ResourceTypeXHR         ResourceType = "XHR"
+	ResourceTypeFetch       ResourceType = "Fetch"
+	ResourceTypeEventSource ResourceType = "EventSource"
+	ResourceTypeWebSocket   ResourceType = "WebSocket"
+	ResourceTypeManifest    ResourceType = "Manifest"
+	ResourceTypeOther       ResourceType = "Other"
 )
 
 // FrameID Unique frame identifier.

--- a/protocol/page18.go
+++ b/protocol/page18.go
@@ -4,100 +4,20 @@
 
 package protocol
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // PageResourceType Resource type as it was perceived by the rendering engine.
-type PageResourceType int
+type PageResourceType string
 
-// Valid returns true if enum is set.
 func (e PageResourceType) Valid() bool {
-	return e >= 1 && e <= 13
+	switch e {
+	case "Document", "Stylesheet", "Image", "Media", "Font", "Script", "TextTrack", "XHR", "Fetch", "EventSource", "WebSocket", "Manifest", "Other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e PageResourceType) String() string {
-	switch e {
-	case 0:
-		return "PageResourceTypeNotSet"
-	case 1:
-		return "Document"
-	case 2:
-		return "Stylesheet"
-	case 3:
-		return "Image"
-	case 4:
-		return "Media"
-	case 5:
-		return "Font"
-	case 6:
-		return "Script"
-	case 7:
-		return "TextTrack"
-	case 8:
-		return "XHR"
-	case 9:
-		return "Fetch"
-	case 10:
-		return "EventSource"
-	case 11:
-		return "WebSocket"
-	case 12:
-		return "Manifest"
-	case 13:
-		return "Other"
-	}
-	return fmt.Sprintf("PageResourceType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e PageResourceType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("protocol.PageResourceType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *PageResourceType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"Document\"":
-		*e = 1
-	case "\"Stylesheet\"":
-		*e = 2
-	case "\"Image\"":
-		*e = 3
-	case "\"Media\"":
-		*e = 4
-	case "\"Font\"":
-		*e = 5
-	case "\"Script\"":
-		*e = 6
-	case "\"TextTrack\"":
-		*e = 7
-	case "\"XHR\"":
-		*e = 8
-	case "\"Fetch\"":
-		*e = 9
-	case "\"EventSource\"":
-		*e = 10
-	case "\"WebSocket\"":
-		*e = 11
-	case "\"Manifest\"":
-		*e = 12
-	case "\"Other\"":
-		*e = 13
-	default:
-		return fmt.Errorf("protocol.PageResourceType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // PageFrameID Unique frame identifier.

--- a/protocol/runtime/types.go
+++ b/protocol/runtime/types.go
@@ -5,7 +5,6 @@ package runtime
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -16,66 +15,28 @@ type ScriptID string
 type RemoteObjectID string
 
 // UnserializableValue Primitive value which cannot be JSON-stringified.
-type UnserializableValue int
+type UnserializableValue string
 
 // UnserializableValue as enums.
 const (
-	UnserializableValueNotSet UnserializableValue = iota
-	UnserializableValueInfinity
-	UnserializableValueNaN
-	UnserializableValueNegativeInfinity
-	UnserializableValueNegative0
+	UnserializableValueNotSet           UnserializableValue = ""
+	UnserializableValueInfinity         UnserializableValue = "Infinity"
+	UnserializableValueNaN              UnserializableValue = "NaN"
+	UnserializableValueNegativeInfinity UnserializableValue = "-Infinity"
+	UnserializableValueNegative0        UnserializableValue = "-0"
 )
 
-// Valid returns true if enum is set.
 func (e UnserializableValue) Valid() bool {
-	return e >= 1 && e <= 4
+	switch e {
+	case "Infinity", "NaN", "-Infinity", "-0":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e UnserializableValue) String() string {
-	switch e {
-	case 0:
-		return "UnserializableValueNotSet"
-	case 1:
-		return "Infinity"
-	case 2:
-		return "NaN"
-	case 3:
-		return "-Infinity"
-	case 4:
-		return "-0"
-	}
-	return fmt.Sprintf("UnserializableValue(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e UnserializableValue) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("runtime.UnserializableValue: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *UnserializableValue) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"Infinity\"":
-		*e = 1
-	case "\"NaN\"":
-		*e = 2
-	case "\"-Infinity\"":
-		*e = 3
-	case "\"-0\"":
-		*e = 4
-	default:
-		return fmt.Errorf("runtime.UnserializableValue: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // RemoteObject Mirror object referencing original JavaScript object.

--- a/protocol/security/types.go
+++ b/protocol/security/types.go
@@ -2,139 +2,57 @@
 
 package security
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // CertificateID An internal certificate ID value.
 type CertificateID int
 
 // MixedContentType A description of mixed content (HTTP resources on HTTPS pages), as defined by https://www.w3.org/TR/mixed-content/#categories
-type MixedContentType int
+type MixedContentType string
 
 // MixedContentType as enums.
 const (
-	MixedContentTypeNotSet MixedContentType = iota
-	MixedContentTypeBlockable
-	MixedContentTypeOptionallyBlockable
-	MixedContentTypeNone
+	MixedContentTypeNotSet              MixedContentType = ""
+	MixedContentTypeBlockable           MixedContentType = "blockable"
+	MixedContentTypeOptionallyBlockable MixedContentType = "optionally-blockable"
+	MixedContentTypeNone                MixedContentType = "none"
 )
 
-// Valid returns true if enum is set.
 func (e MixedContentType) Valid() bool {
-	return e >= 1 && e <= 3
+	switch e {
+	case "blockable", "optionally-blockable", "none":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e MixedContentType) String() string {
-	switch e {
-	case 0:
-		return "MixedContentTypeNotSet"
-	case 1:
-		return "blockable"
-	case 2:
-		return "optionally-blockable"
-	case 3:
-		return "none"
-	}
-	return fmt.Sprintf("MixedContentType(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e MixedContentType) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("security.MixedContentType: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *MixedContentType) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"blockable\"":
-		*e = 1
-	case "\"optionally-blockable\"":
-		*e = 2
-	case "\"none\"":
-		*e = 3
-	default:
-		return fmt.Errorf("security.MixedContentType: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // State The security level of a page or resource.
-type State int
+type State string
 
 // State as enums.
 const (
-	StateNotSet State = iota
-	StateUnknown
-	StateNeutral
-	StateInsecure
-	StateSecure
-	StateInfo
+	StateNotSet   State = ""
+	StateUnknown  State = "unknown"
+	StateNeutral  State = "neutral"
+	StateInsecure State = "insecure"
+	StateSecure   State = "secure"
+	StateInfo     State = "info"
 )
 
-// Valid returns true if enum is set.
 func (e State) Valid() bool {
-	return e >= 1 && e <= 5
+	switch e {
+	case "unknown", "neutral", "insecure", "secure", "info":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e State) String() string {
-	switch e {
-	case 0:
-		return "StateNotSet"
-	case 1:
-		return "unknown"
-	case 2:
-		return "neutral"
-	case 3:
-		return "insecure"
-	case 4:
-		return "secure"
-	case 5:
-		return "info"
-	}
-	return fmt.Sprintf("State(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e State) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("security.State: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *State) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"unknown\"":
-		*e = 1
-	case "\"neutral\"":
-		*e = 2
-	case "\"insecure\"":
-		*e = 3
-	case "\"secure\"":
-		*e = 4
-	case "\"info\"":
-		*e = 5
-	default:
-		return fmt.Errorf("security.State: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // StateExplanation An explanation of an factor contributing to the security state.
@@ -158,54 +76,24 @@ type InsecureContentStatus struct {
 }
 
 // CertificateErrorAction The action to take when a certificate error occurs. continue will continue processing the request and cancel will cancel the request.
-type CertificateErrorAction int
+type CertificateErrorAction string
 
 // CertificateErrorAction as enums.
 const (
-	CertificateErrorActionNotSet CertificateErrorAction = iota
-	CertificateErrorActionContinue
-	CertificateErrorActionCancel
+	CertificateErrorActionNotSet   CertificateErrorAction = ""
+	CertificateErrorActionContinue CertificateErrorAction = "continue"
+	CertificateErrorActionCancel   CertificateErrorAction = "cancel"
 )
 
-// Valid returns true if enum is set.
 func (e CertificateErrorAction) Valid() bool {
-	return e >= 1 && e <= 2
+	switch e {
+	case "continue", "cancel":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e CertificateErrorAction) String() string {
-	switch e {
-	case 0:
-		return "CertificateErrorActionNotSet"
-	case 1:
-		return "continue"
-	case 2:
-		return "cancel"
-	}
-	return fmt.Sprintf("CertificateErrorAction(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e CertificateErrorAction) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("security.CertificateErrorAction: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *CertificateErrorAction) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"continue\"":
-		*e = 1
-	case "\"cancel\"":
-		*e = 2
-	default:
-		return fmt.Errorf("security.CertificateErrorAction: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }

--- a/protocol/serviceworker/types.go
+++ b/protocol/serviceworker/types.go
@@ -3,10 +3,6 @@
 package serviceworker
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/mafredri/cdp/protocol/target"
 )
 
@@ -18,139 +14,55 @@ type Registration struct {
 }
 
 // VersionRunningStatus
-type VersionRunningStatus int
+type VersionRunningStatus string
 
 // VersionRunningStatus as enums.
 const (
-	VersionRunningStatusNotSet VersionRunningStatus = iota
-	VersionRunningStatusStopped
-	VersionRunningStatusStarting
-	VersionRunningStatusRunning
-	VersionRunningStatusStopping
+	VersionRunningStatusNotSet   VersionRunningStatus = ""
+	VersionRunningStatusStopped  VersionRunningStatus = "stopped"
+	VersionRunningStatusStarting VersionRunningStatus = "starting"
+	VersionRunningStatusRunning  VersionRunningStatus = "running"
+	VersionRunningStatusStopping VersionRunningStatus = "stopping"
 )
 
-// Valid returns true if enum is set.
 func (e VersionRunningStatus) Valid() bool {
-	return e >= 1 && e <= 4
+	switch e {
+	case "stopped", "starting", "running", "stopping":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e VersionRunningStatus) String() string {
-	switch e {
-	case 0:
-		return "VersionRunningStatusNotSet"
-	case 1:
-		return "stopped"
-	case 2:
-		return "starting"
-	case 3:
-		return "running"
-	case 4:
-		return "stopping"
-	}
-	return fmt.Sprintf("VersionRunningStatus(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e VersionRunningStatus) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("serviceworker.VersionRunningStatus: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *VersionRunningStatus) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"stopped\"":
-		*e = 1
-	case "\"starting\"":
-		*e = 2
-	case "\"running\"":
-		*e = 3
-	case "\"stopping\"":
-		*e = 4
-	default:
-		return fmt.Errorf("serviceworker.VersionRunningStatus: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // VersionStatus
-type VersionStatus int
+type VersionStatus string
 
 // VersionStatus as enums.
 const (
-	VersionStatusNotSet VersionStatus = iota
-	VersionStatusNew
-	VersionStatusInstalling
-	VersionStatusInstalled
-	VersionStatusActivating
-	VersionStatusActivated
-	VersionStatusRedundant
+	VersionStatusNotSet     VersionStatus = ""
+	VersionStatusNew        VersionStatus = "new"
+	VersionStatusInstalling VersionStatus = "installing"
+	VersionStatusInstalled  VersionStatus = "installed"
+	VersionStatusActivating VersionStatus = "activating"
+	VersionStatusActivated  VersionStatus = "activated"
+	VersionStatusRedundant  VersionStatus = "redundant"
 )
 
-// Valid returns true if enum is set.
 func (e VersionStatus) Valid() bool {
-	return e >= 1 && e <= 6
+	switch e {
+	case "new", "installing", "installed", "activating", "activated", "redundant":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e VersionStatus) String() string {
-	switch e {
-	case 0:
-		return "VersionStatusNotSet"
-	case 1:
-		return "new"
-	case 2:
-		return "installing"
-	case 3:
-		return "installed"
-	case 4:
-		return "activating"
-	case 5:
-		return "activated"
-	case 6:
-		return "redundant"
-	}
-	return fmt.Sprintf("VersionStatus(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e VersionStatus) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("serviceworker.VersionStatus: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *VersionStatus) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"new\"":
-		*e = 1
-	case "\"installing\"":
-		*e = 2
-	case "\"installed\"":
-		*e = 3
-	case "\"activating\"":
-		*e = 4
-	case "\"activated\"":
-		*e = 5
-	case "\"redundant\"":
-		*e = 6
-	default:
-		return fmt.Errorf("serviceworker.VersionStatus: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // Version ServiceWorker version.

--- a/protocol/storage/types.go
+++ b/protocol/storage/types.go
@@ -2,108 +2,36 @@
 
 package storage
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // Type Enum of possible storage types.
-type Type int
+type Type string
 
 // Type as enums.
 const (
-	TypeNotSet Type = iota
-	TypeAppcache
-	TypeCookies
-	TypeFileSystems
-	TypeIndexeddb
-	TypeLocalStorage
-	TypeShaderCache
-	TypeWebsql
-	TypeServiceWorkers
-	TypeCacheStorage
-	TypeAll
-	TypeOther
+	TypeNotSet         Type = ""
+	TypeAppcache       Type = "appcache"
+	TypeCookies        Type = "cookies"
+	TypeFileSystems    Type = "file_systems"
+	TypeIndexeddb      Type = "indexeddb"
+	TypeLocalStorage   Type = "local_storage"
+	TypeShaderCache    Type = "shader_cache"
+	TypeWebsql         Type = "websql"
+	TypeServiceWorkers Type = "service_workers"
+	TypeCacheStorage   Type = "cache_storage"
+	TypeAll            Type = "all"
+	TypeOther          Type = "other"
 )
 
-// Valid returns true if enum is set.
 func (e Type) Valid() bool {
-	return e >= 1 && e <= 11
+	switch e {
+	case "appcache", "cookies", "file_systems", "indexeddb", "local_storage", "shader_cache", "websql", "service_workers", "cache_storage", "all", "other":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e Type) String() string {
-	switch e {
-	case 0:
-		return "TypeNotSet"
-	case 1:
-		return "appcache"
-	case 2:
-		return "cookies"
-	case 3:
-		return "file_systems"
-	case 4:
-		return "indexeddb"
-	case 5:
-		return "local_storage"
-	case 6:
-		return "shader_cache"
-	case 7:
-		return "websql"
-	case 8:
-		return "service_workers"
-	case 9:
-		return "cache_storage"
-	case 10:
-		return "all"
-	case 11:
-		return "other"
-	}
-	return fmt.Sprintf("Type(%d)", e)
-}
-
-// MarshalJSON encodes enum into a string or null when not set.
-func (e Type) MarshalJSON() ([]byte, error) {
-	if e == 0 {
-		return []byte("null"), nil
-	}
-	if !e.Valid() {
-		return nil, errors.New("storage.Type: MarshalJSON on bad enum value: " + e.String())
-	}
-	return json.Marshal(e.String())
-}
-
-// UnmarshalJSON decodes a string value into a enum.
-func (e *Type) UnmarshalJSON(data []byte) error {
-	switch string(data) {
-	case "null":
-		*e = 0
-	case "\"appcache\"":
-		*e = 1
-	case "\"cookies\"":
-		*e = 2
-	case "\"file_systems\"":
-		*e = 3
-	case "\"indexeddb\"":
-		*e = 4
-	case "\"local_storage\"":
-		*e = 5
-	case "\"shader_cache\"":
-		*e = 6
-	case "\"websql\"":
-		*e = 7
-	case "\"service_workers\"":
-		*e = 8
-	case "\"cache_storage\"":
-		*e = 9
-	case "\"all\"":
-		*e = 10
-	case "\"other\"":
-		*e = 11
-	default:
-		return fmt.Errorf("storage.Type: UnmarshalJSON on bad input: %s", data)
-	}
-	return nil
+	return string(e)
 }
 
 // UsageForType Usage for a storage type.


### PR DESCRIPTION
This PR changes `int`-based enums into `string`-based ones and is largely backwards-compatible with the previous implementation.

Motivations for this change:
* The `int` enums keep changing in value as the protocol definitions are modified
    * This is apparent in e.g. https://github.com/mafredri/cdp/commit/38ea0dffd17432c72ef95186d7caefe0cc76e56f#diff-f9a7695adb5d518e7d3361797ed8477b where `security.StateInfo` changed from `6` to `5` as `StateWarning` was removed.
* Even small variations in the browser protocol and `cdp` could cause the json unmarshaling to produce an error
    * Say that a new type is added to an enum in the browser, when `cdp` tries to decode it there will be no `int` representation for it and an error will be returned
* The `int` enums cannot reliably be serialized/stored and used with a newer or older version of `cdp` due to the change in int values
* More convenient for the user as they can use the string value directly if they choose to

Negatives:
* Less validation for when the browser is returning unexpected enum values
    * However, the user can use `(enum).Valid()` to manually verify if `cdp` knows this enum value