### PR TITLE
Add WebSocketDebuggerURL to devtool.Version struct

### DIFF
--- a/devtool/devtool.go
+++ b/devtool/devtool.go
@@ -179,6 +179,9 @@ type Version struct {
 
 	// Present on Android.
 	AndroidPackage string `json:"Android-Package"`
+
+	// Present in Chrome >= 62. Generic browser websocket URL.
+	WebSocketDebuggerURL string `json:"websocketDebuggerUrl"`
 }
 
 // Version returns the version information for the DevTools endpoint.

--- a/devtool/testdata/test.golden
+++ b/devtool/testdata/test.golden
@@ -9,4 +9,4 @@ Close: <nil> <nil>
 GET /json/activate/ddd908ca-4d8c-4783-a089-c9456c463eef
 Activate: <nil> <nil>
 GET /json/version
-Version: &{Chrome/59.0.3040.0 1.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3040.0 Safari/537.36 5.9.35 537.36 (@c020f6a22577978ce1fe89fc1a397f2a651c48a8) } <nil>
+Version: &{Chrome/59.0.3040.0 1.2 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3040.0 Safari/537.36 5.9.35 537.36 (@c020f6a22577978ce1fe89fc1a397f2a651c48a8)  ws://localhost:9222/devtools/browser/74ffefaa-3f6b-4d25-8fb3-98b85d7bf1cd} <nil>

--- a/devtool/testdata/version.json
+++ b/devtool/testdata/version.json
@@ -3,5 +3,6 @@
    "Protocol-Version": "1.2",
    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3040.0 Safari/537.36",
    "V8-Version": "5.9.35",
-   "WebKit-Version": "537.36 (@c020f6a22577978ce1fe89fc1a397f2a651c48a8)"
+   "WebKit-Version": "537.36 (@c020f6a22577978ce1fe89fc1a397f2a651c48a8)",
+   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/74ffefaa-3f6b-4d25-8fb3-98b85d7bf1cd"
 }


### PR DESCRIPTION
In Chrome >= 62, the `/devtools/browser` websocket endpoint was removed and replaced with a `/devtools/browser/<UUID>` endpoint ([ref][1]). The UUID is generated when the process starts but the full websocket URL can now be obtained from `/json/version`:

```js
$ curl -s https://localhost:9222/json/version
{
   "Browser": "HeadlessChrome/63.0.3236.7",
   "Protocol-Version": "1.2",
   "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/63.0.3236.7 Safari/537.36",
   "V8-Version": "6.3.272",
   "WebKit-Version": "537.36 (@a1d99e4bc8bf4b58b0717cb406cfe70a9977e9ad)",
   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/74ffefaa-3f6b-4d25-8fb3-98b85d7bf1cd"
 }
```

This patch just adds the WebSocketDebuggerURL struct member to the `devtool.Version` struct so I can get at it from calling code.

There's also some (now broken) logic in `devtool.headlessCreateURL` that uses the `/devtools/browser` URL. I could take a crack at adapting it but wanted to see if I'm moving in a direction you'd be interested in.