### PR TITLE
devtool: Lift URL scheme restriction

### DIFF
--- a/devtool/devtool.go
+++ b/devtool/devtool.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"regexp"
 )
 
 // DevToolsOption represents a function that sets a DevTools option.
@@ -69,15 +68,13 @@ func (d *DevTools) Create(ctx context.Context) (*Target, error) {
 	return d.CreateURL(ctx, "")
 }
 
-var httpRe = regexp.MustCompile("^https?://")
-
 // CreateURL is like Create but opens the provided URL. The URL must be
 // valid and begin with "http://" or "https://".
 func (d *DevTools) CreateURL(ctx context.Context, openURL string) (*Target, error) {
 	var escapedQueryURL string
 
 	if openURL != "" {
-		if !httpRe.MatchString(openURL) {
+		if parsed, err := url.Parse(openURL); err != nil || !parsed.IsAbs() {
 			return nil, errors.New("devtool: CreateURL: invalid openURL: " + openURL)
 		}
 		escapedQueryURL = "?" + url.QueryEscape(openURL)

--- a/devtool/headless.go
+++ b/devtool/headless.go
@@ -3,11 +3,14 @@ package devtool
 import (
 	"context"
 	"errors"
+	"regexp"
 
 	"github.com/mafredri/cdp"
 	"github.com/mafredri/cdp/protocol/target"
 	"github.com/mafredri/cdp/rpcc"
 )
+
+var httpRe = regexp.MustCompile("^https?://")
 
 // headlessCreateURL tries to create a new target for Headless Chrome that does
 // not support the json new endpoint. A rpcc connection is established to the


### PR DESCRIPTION
Instead of whitelisting http/https URLs only, check that the given
URL has a non-empty scheme.

Fixes #70.