### PR TITLE
devtool: Avoid fallback websocket during Create if Chrome is too new

### DIFF
--- a/devtool/devtool.go
+++ b/devtool/devtool.go
@@ -3,11 +3,12 @@ package devtool
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/mafredri/cdp/internal/errors"
 )
 
 // DevToolsOption represents a function that sets a DevTools option.
@@ -90,7 +91,18 @@ func (d *DevTools) CreateURL(ctx context.Context, openURL string) (*Target, erro
 	// Returned by Headless Chrome that does
 	// not support the "/json/new" endpoint.
 	case http.StatusInternalServerError:
-		return headlessCreateURL(ctx, d, openURL)
+		err2 := err
+		v, err := d.Version(ctx)
+		if err != nil {
+			return nil, errors.Merge(err, err2)
+		}
+
+		if v.WebSocketDebuggerURL != "" {
+			// This version is too new since it has a debugger URL set.
+			return nil, err2
+		}
+
+		return fallbackHeadlessCreateURL(ctx, d, openURL)
 
 	case http.StatusOK:
 		t := new(Target)

--- a/devtool/devtool.go
+++ b/devtool/devtool.go
@@ -95,7 +95,7 @@ func (d *DevTools) CreateURL(ctx context.Context, openURL string) (*Target, erro
 
 		v, err := d.Version(ctx)
 		if err != nil {
-			return nil, errors.Merge(err, err2)
+			return nil, err2
 		}
 
 		if v.WebSocketDebuggerURL != "" {

--- a/devtool/devtool.go
+++ b/devtool/devtool.go
@@ -91,7 +91,8 @@ func (d *DevTools) CreateURL(ctx context.Context, openURL string) (*Target, erro
 	// Returned by Headless Chrome that does
 	// not support the "/json/new" endpoint.
 	case http.StatusInternalServerError:
-		err2 := err
+		err2 := parseError("CreateUrl: StatusInternalServerError", resp.Body)
+
 		v, err := d.Version(ctx)
 		if err != nil {
 			return nil, errors.Merge(err, err2)

--- a/devtool/headless.go
+++ b/devtool/headless.go
@@ -12,10 +12,10 @@ import (
 
 var httpRe = regexp.MustCompile("^https?://")
 
-// headlessCreateURL tries to create a new target for Headless Chrome that does
-// not support the json new endpoint. A rpcc connection is established to the
-// "/devtools/browser" endpoint and "Target.createTarget" is issued.
-func headlessCreateURL(ctx context.Context, d *DevTools, openURL string) (*Target, error) {
+// fallbackHeadlessCreateURL tries to create a new target for Headless Chrome
+// that does not support the json new endpoint. A rpcc connection is established
+// to the "/devtools/browser" endpoint and "Target.createTarget" is issued.
+func fallbackHeadlessCreateURL(ctx context.Context, d *DevTools, openURL string) (*Target, error) {
 	// Context must be set, rpcc DialContext panics on nil context.
 	if ctx == nil {
 		ctx = context.Background()


### PR DESCRIPTION
Fixes #75.