### PR TITLE
devtool: Resolve hostname to IP address

### DIFF
--- a/devtool/devtool.go
+++ b/devtool/devtool.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 
 	"github.com/mafredri/cdp/internal/errors"
 )
@@ -27,6 +30,9 @@ func WithClient(client *http.Client) DevToolsOption {
 type DevTools struct {
 	url    string
 	client *http.Client
+
+	mu     sync.Mutex // Protects following.
+	lookup bool
 }
 
 // New returns a DevTools instance that uses URL.
@@ -215,12 +221,79 @@ func (d *DevTools) httpGet(ctx context.Context, path string) (*http.Response, er
 		ctx = context.Background()
 	}
 
+	err := d.resolveHost(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest(http.MethodGet, d.url+path, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	return d.client.Do(req.WithContext(ctx))
+}
+
+// resolveHost does a lookup on the hostname in d.url and tries to
+// replace it with a valid IP address. Ever since Chrome 66, the
+// DevTools endpoint disallows hostnames other than "localhost".
+//
+// Example error:
+// < HTTP/1.1 500 Internal Server Error
+// < Content-Length:63
+// < Content-Type:text/html
+// <
+// Host header is specified and is not an IP address or localhost.
+func (d *DevTools) resolveHost(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.lookup {
+		return nil
+	}
+	d.lookup = true
+
+	u, err := url.Parse(d.url)
+	if err != nil {
+		return err
+	}
+	host := strings.Split(u.Host, ":")
+	origHost := host[0]
+
+	if origHost == "localhost" {
+		return nil // Nothing to do, localhost is allowed.
+	}
+
+	addrs, err := net.DefaultResolver.LookupHost(ctx, origHost)
+	if err != nil {
+		return err
+	}
+
+	newURL := ""
+	for _, a := range addrs {
+		host[0] = a
+		u.Host = strings.Join(host, ":")
+		try := u.String()
+
+		// The selection of "/json/version" here is arbitrary,
+		// it just needs to exist and not have side-effects.
+		req, err := http.NewRequest(http.MethodGet, try+"/json/version", nil)
+		if err != nil {
+			return err
+		}
+
+		resp, err := d.client.Do(req.WithContext(ctx))
+		if err == nil && resp.StatusCode == 200 {
+			newURL = try
+			break
+		}
+	}
+	if newURL == "" {
+		return errors.New("could not resolve IP for " + origHost)
+	}
+	d.url = newURL
+
+	return nil
 }
 
 func parseError(from string, r io.Reader) error {

--- a/devtool/devtool_test.go
+++ b/devtool/devtool_test.go
@@ -22,6 +22,10 @@ type testHandler struct {
 	status int
 	body   []byte
 	buf    *bytes.Buffer
+
+	// This is used to inform testHandler that a
+	// hostname lookup will be performed next.
+	hostnameLookup bool
 }
 
 func newTestHandler(t *testing.T) *testHandler {
@@ -35,6 +39,12 @@ func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			h.t.Error(err)
 		}
+		return
+	}
+	if h.hostnameLookup {
+		h.hostnameLookup = false
+		w.WriteHeader(200)
+		w.Write([]byte("{}"))
 		return
 	}
 	if h.buf != nil {
@@ -69,6 +79,7 @@ func TestDevTools(t *testing.T) {
 	defer srv.Close()
 
 	devt := New(srv.URL)
+	th.hostnameLookup = true
 
 	var buf bytes.Buffer
 	th.buf = &buf
@@ -138,6 +149,7 @@ func TestDevTools_Error(t *testing.T) {
 	defer srv.Close()
 
 	devt := New(srv.URL)
+	th.hostnameLookup = true
 
 	var buf bytes.Buffer
 

--- a/devtool/headless_test.go
+++ b/devtool/headless_test.go
@@ -65,6 +65,7 @@ func TestDevTools_HeadlessCreateURL(t *testing.T) {
 	mh := &multiHandler{
 		t: t,
 		h: []http.Handler{
+			&testHandler{hostnameLookup: true},
 			&testHandler{status: 500},
 			&testHandler{status: 200, body: []byte(`{
 				"Browser": "HeadlessChrome/60.0.3578.30"


### PR DESCRIPTION
This commit makes devtool resolve any given hostname (except localhost) to a valid IP address. We do this for user convenience as Chrome blocks attempts at setting the Host header in requests unless it's localhost.

Since devtool.New doesn't return an error, we must unfortunately delay this lookup until the user does a request. Otherwise we would have to break the API.

Related to #75.