### PR TITLE
rpcc: Fix stream sync deadlock

### DIFF
--- a/rpcc/conn.go
+++ b/rpcc/conn.go
@@ -426,6 +426,8 @@ func (c *Conn) notify(method string, data []byte) {
 	c.streamMu.Unlock()
 
 	if stream != nil {
+		// Stream writer must be able to handle incoming writes
+		// even after it has been removed (unsubscribed).
 		stream.write(method, data)
 	}
 }
@@ -448,7 +450,8 @@ func (c *Conn) listen(method string, w streamWriter) (func(), error) {
 	}
 	seq := stream.add(w)
 
-	return func() { stream.remove(seq) }, nil
+	unsub := func() { stream.remove(seq) }
+	return unsub, nil
 }
 
 // Close closes the connection.

--- a/rpcc/conn.go
+++ b/rpcc/conn.go
@@ -423,10 +423,11 @@ func (c *Conn) send(ctx context.Context, call *rpcCall) (err error) {
 func (c *Conn) notify(method string, data []byte) {
 	c.streamMu.Lock()
 	stream := c.streams[method]
+	c.streamMu.Unlock()
+
 	if stream != nil {
 		stream.write(method, data)
 	}
-	c.streamMu.Unlock()
 }
 
 // listen registers a new stream listener (chan) for the RPC notification

--- a/rpcc/stream.go
+++ b/rpcc/stream.go
@@ -280,7 +280,7 @@ func (s *streamClient) close(err error) error {
 		err = ErrStreamClosing
 	}
 
-	remove()    // Unsubscribe first to prevent incoming messages.
+	remove()    // Unsubscribe to prevent new messages.
 	s.err = err // Set err before cancel as reads are protected by context.
 	close(s.done)
 

--- a/rpcc/stream_sync.go
+++ b/rpcc/stream_sync.go
@@ -125,6 +125,14 @@ func Sync(s ...Stream) (err error) {
 		return errors.New("rpcc: Sync: two or more streams must be provided")
 	}
 
+	set := make(map[Stream]struct{})
+	for _, ss := range s {
+		if _, ok := set[ss]; ok {
+			return errors.New("rpcc: Sync: same instance of stream passed multiple times")
+		}
+		set[ss] = struct{}{}
+	}
+
 	store := newSyncMessageStore()
 	defer func() {
 		if err != nil {

--- a/rpcc/stream_sync_test.go
+++ b/rpcc/stream_sync_test.go
@@ -150,3 +150,26 @@ func TestSyncError(t *testing.T) {
 
 	}
 }
+
+func TestStreamSyncNotifyDeadlock(t *testing.T) {
+	conn, cancel := newTestStreamConn()
+	defer cancel()
+
+	ctx := context.Background()
+
+	s1, err := NewStream(ctx, "test1", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := NewStream(ctx, "test2", conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go conn.notify("test1", []byte(`{"hello": "world"}`))
+
+	err = Sync(s1, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/rpcc/stream_sync_test.go
+++ b/rpcc/stream_sync_test.go
@@ -213,11 +213,11 @@ func TestStreamSyncClosingStreams(t *testing.T) {
 	testStreams := []struct {
 		name string
 	}{
+		{name: "test0"},
 		{name: "test1"},
 		{name: "test2"},
 		{name: "test3"},
 		{name: "test4"},
-		{name: "test5"},
 	}
 
 	var streams []Stream
@@ -238,15 +238,15 @@ func TestStreamSyncClosingStreams(t *testing.T) {
 
 		<-readySteadyGo
 		go streams[2].Close()
+		conn.notify("test0", []byte("test0.0"))
 		conn.notify("test1", []byte("test1.0"))
 		conn.notify("test2", []byte("test2.0"))
+		conn.notify("test2", []byte("test2.1"))
+		conn.notify("test2", []byte("test2.2"))
 		conn.notify("test3", []byte("test3.0"))
 		conn.notify("test3", []byte("test3.1"))
-		conn.notify("test3", []byte("test3.2"))
-		conn.notify("test4", []byte("test4.0"))
-		conn.notify("test4", []byte("test4.1"))
 		streams[3].Close()
-		conn.notify("test5", []byte("test5.0"))
+		conn.notify("test4", []byte("test4.0"))
 	}()
 
 	for i, s := range streams {


### PR DESCRIPTION
This PR addresses two edge cases related to Sync.

The first issue, reported in #90 was that a deadlock was triggered if an incoming RPC notification to a stream that was being synced, via Sync, was timed perfectly. The event loop is such that:
1. Sync: Creates a new `syncMessageStore`
2. Sync: The first stream is for notifications named `"hello"`
2. Sync: `(*syncMessageStore).subscribe` invokes `(*Conn).listen` for `"hello"` and places itself as a listener for hello notifications
3. Notify(hello): An incoming notification invokes `(*Conn).notify` for `"hello"` and acquires a lock on `(*Conn).streamMu`
4. Sync: `(*syncMessageStore).subscribe` is invoked for the next stream, a lock on `(*syncMessageStore).mu` is acquired
5. Notify(hello): Invokes `(*syncMessageStore).write` which tries to acquire a lock on `(*syncMessageStore).mu` which is **already locked**
6. Sync: `(*syncMessageStore).subscribe` invokes `(*Conn).listen` which tries to acquire a lock on `(*Conn).streamMu` which is **already locked**

This issue is addressed by releasing `(*Conn).streamMu` before invoking `(*syncMessageStore).write`.

The second issue prevents a deadlock when the same stream is passed multiple times to Sync.

Fixes #90.