### PR TITLE
In session.go, explicitly specificy flatten=false for the AttachToTarget command.

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -89,6 +89,10 @@ var (
 // the underlying *rpcc.Conn for the provided *cdp.Client.
 func dial(ctx context.Context, id target.ID, tc *cdp.Client, detachTimeout time.Duration) (s *session, err error) {
 	args := target.NewAttachToTargetArgs(id)
+	// The default of this flag will change to true, so until CDP
+	// uses flat session mode, we set this to false explicitly.
+	// See https://bugs.chromium.org/p/chromium/issues/detail?id=991325.
+	args.SetFlatten(false)
 	reply, err := tc.Target.AttachToTarget(ctx, args)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I'm working on deprecating the non-flat session mode in favor of flat session mode (https://bugs.chromium.org/p/chromium/issues/detail?id=991325). So until CDP supports flat sessions, I'd like to flip this flag explicitly to false so I can change the default to true.

Thanks much for considering!