### PR TITLE
Sketch for implementing sessions with flattened protocol.

### DIFF
--- a/cdp_client.go
+++ b/cdp_client.go
@@ -54,6 +54,7 @@ import (
 // invoke methods or listen to events in every CDP domain. The Client consumes
 // a rpcc connection, used to invoke the methods.
 type Client struct {
+	Conn                 *rpcc.Conn
 	Accessibility        Accessibility
 	Animation            Animation
 	ApplicationCache     ApplicationCache
@@ -104,6 +105,7 @@ type Client struct {
 // for communication with the debugging target.
 func NewClient(conn *rpcc.Conn) *Client {
 	return &Client{
+		Conn:                 conn,
 		Accessibility:        accessibility.NewClient(conn),
 		Animation:            animation.NewClient(conn),
 		ApplicationCache:     applicationcache.NewClient(conn),
@@ -148,5 +150,54 @@ func NewClient(conn *rpcc.Conn) *Client {
 		Tracing:              tracing.NewClient(conn),
 		WebAudio:             webaudio.NewClient(conn),
 		WebAuthn:             webauthn.NewClient(conn),
+	}
+}
+
+func (c *Client) NewSession(sessionID string) *Client {
+	return &Client{
+		Accessibility:        accessibility.NewSessionClient(c.Conn, sessionID),
+		Animation:            animation.NewSessionClient(c.Conn, sessionID),
+		ApplicationCache:     applicationcache.NewSessionClient(c.Conn, sessionID),
+		Audits:               audits.NewSessionClient(c.Conn, sessionID),
+		BackgroundService:    backgroundservice.NewSessionClient(c.Conn, sessionID),
+		Browser:              browser.NewSessionClient(c.Conn, sessionID),
+		CSS:                  css.NewSessionClient(c.Conn, sessionID),
+		CacheStorage:         cachestorage.NewSessionClient(c.Conn, sessionID),
+		Cast:                 cast.NewSessionClient(c.Conn, sessionID),
+		Console:              console.NewSessionClient(c.Conn, sessionID),
+		DOM:                  dom.NewSessionClient(c.Conn, sessionID),
+		DOMDebugger:          domdebugger.NewSessionClient(c.Conn, sessionID),
+		DOMSnapshot:          domsnapshot.NewSessionClient(c.Conn, sessionID),
+		DOMStorage:           domstorage.NewSessionClient(c.Conn, sessionID),
+		Database:             database.NewSessionClient(c.Conn, sessionID),
+		Debugger:             debugger.NewSessionClient(c.Conn, sessionID),
+		DeviceOrientation:    deviceorientation.NewSessionClient(c.Conn, sessionID),
+		Emulation:            emulation.NewSessionClient(c.Conn, sessionID),
+		Fetch:                fetch.NewSessionClient(c.Conn, sessionID),
+		HeadlessExperimental: headlessexperimental.NewSessionClient(c.Conn, sessionID),
+		HeapProfiler:         heapprofiler.NewSessionClient(c.Conn, sessionID),
+		IO:                   io.NewSessionClient(c.Conn, sessionID),
+		IndexedDB:            indexeddb.NewSessionClient(c.Conn, sessionID),
+		Input:                input.NewSessionClient(c.Conn, sessionID),
+		Inspector:            inspector.NewSessionClient(c.Conn, sessionID),
+		LayerTree:            layertree.NewSessionClient(c.Conn, sessionID),
+		Log:                  log.NewSessionClient(c.Conn, sessionID),
+		Memory:               memory.NewSessionClient(c.Conn, sessionID),
+		Network:              network.NewSessionClient(c.Conn, sessionID),
+		Overlay:              overlay.NewSessionClient(c.Conn, sessionID),
+		Page:                 page.NewSessionClient(c.Conn, sessionID),
+		Performance:          performance.NewSessionClient(c.Conn, sessionID),
+		Profiler:             profiler.NewSessionClient(c.Conn, sessionID),
+		Runtime:              runtime.NewSessionClient(c.Conn, sessionID),
+		Schema:               schema.NewSessionClient(c.Conn, sessionID),
+		Security:             security.NewSessionClient(c.Conn, sessionID),
+		ServiceWorker:        serviceworker.NewSessionClient(c.Conn, sessionID),
+		Storage:              storage.NewSessionClient(c.Conn, sessionID),
+		SystemInfo:           systeminfo.NewSessionClient(c.Conn, sessionID),
+		Target:               target.NewSessionClient(c.Conn, sessionID),
+		Tethering:            tethering.NewSessionClient(c.Conn, sessionID),
+		Tracing:              tracing.NewSessionClient(c.Conn, sessionID),
+		WebAudio:             webaudio.NewSessionClient(c.Conn, sessionID),
+		WebAuthn:             webauthn.NewSessionClient(c.Conn, sessionID),
 	}
 }

--- a/protocol/accessibility/domain.go
+++ b/protocol/accessibility/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the Accessibility domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Accessibility domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Accessibility domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Accessibility method. Disables the accessibility
 // domain.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Accessibility.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Accessibility.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Accessibility", Op: "Disable", Err: err}
 	}
@@ -33,7 +41,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // turns on accessibility for the page, which can impact performance until
 // accessibility is disabled.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Accessibility.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Accessibility.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Accessibility", Op: "Enable", Err: err}
 	}
@@ -46,9 +54,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) GetPartialAXTree(ctx context.Context, args *GetPartialAXTreeArgs) (reply *GetPartialAXTreeReply, err error) {
 	reply = new(GetPartialAXTreeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Accessibility.getPartialAXTree", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Accessibility.getPartialAXTree", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Accessibility.getPartialAXTree", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Accessibility.getPartialAXTree", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Accessibility", Op: "GetPartialAXTree", Err: err}
@@ -60,7 +68,7 @@ func (d *domainClient) GetPartialAXTree(ctx context.Context, args *GetPartialAXT
 // accessibility tree
 func (d *domainClient) GetFullAXTree(ctx context.Context) (reply *GetFullAXTreeReply, err error) {
 	reply = new(GetFullAXTreeReply)
-	err = rpcc.Invoke(ctx, "Accessibility.getFullAXTree", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Accessibility.getFullAXTree", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Accessibility", Op: "GetFullAXTree", Err: err}
 	}

--- a/protocol/animation/domain.go
+++ b/protocol/animation/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the Animation domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Animation domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Animation domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Animation method. Disables animation domain
 // notifications.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Animation.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Animation.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "Disable", Err: err}
 	}
@@ -31,7 +39,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Enable invokes the Animation method. Enables animation domain
 // notifications.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Animation.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Animation.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "Enable", Err: err}
 	}
@@ -43,9 +51,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) GetCurrentTime(ctx context.Context, args *GetCurrentTimeArgs) (reply *GetCurrentTimeReply, err error) {
 	reply = new(GetCurrentTimeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.getCurrentTime", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.getCurrentTime", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.getCurrentTime", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.getCurrentTime", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "GetCurrentTime", Err: err}
@@ -57,7 +65,7 @@ func (d *domainClient) GetCurrentTime(ctx context.Context, args *GetCurrentTimeA
 // document timeline.
 func (d *domainClient) GetPlaybackRate(ctx context.Context) (reply *GetPlaybackRateReply, err error) {
 	reply = new(GetPlaybackRateReply)
-	err = rpcc.Invoke(ctx, "Animation.getPlaybackRate", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Animation.getPlaybackRate", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "GetPlaybackRate", Err: err}
 	}
@@ -68,9 +76,9 @@ func (d *domainClient) GetPlaybackRate(ctx context.Context) (reply *GetPlaybackR
 // animations to no longer be manipulated.
 func (d *domainClient) ReleaseAnimations(ctx context.Context, args *ReleaseAnimationsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.releaseAnimations", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.releaseAnimations", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.releaseAnimations", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.releaseAnimations", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "ReleaseAnimations", Err: err}
@@ -83,9 +91,9 @@ func (d *domainClient) ReleaseAnimations(ctx context.Context, args *ReleaseAnima
 func (d *domainClient) ResolveAnimation(ctx context.Context, args *ResolveAnimationArgs) (reply *ResolveAnimationReply, err error) {
 	reply = new(ResolveAnimationReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.resolveAnimation", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.resolveAnimation", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.resolveAnimation", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.resolveAnimation", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "ResolveAnimation", Err: err}
@@ -97,9 +105,9 @@ func (d *domainClient) ResolveAnimation(ctx context.Context, args *ResolveAnimat
 // particular time within each animation.
 func (d *domainClient) SeekAnimations(ctx context.Context, args *SeekAnimationsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.seekAnimations", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.seekAnimations", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.seekAnimations", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.seekAnimations", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "SeekAnimations", Err: err}
@@ -111,9 +119,9 @@ func (d *domainClient) SeekAnimations(ctx context.Context, args *SeekAnimationsA
 // animations.
 func (d *domainClient) SetPaused(ctx context.Context, args *SetPausedArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.setPaused", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.setPaused", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.setPaused", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.setPaused", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "SetPaused", Err: err}
@@ -125,9 +133,9 @@ func (d *domainClient) SetPaused(ctx context.Context, args *SetPausedArgs) (err 
 // document timeline.
 func (d *domainClient) SetPlaybackRate(ctx context.Context, args *SetPlaybackRateArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.setPlaybackRate", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.setPlaybackRate", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.setPlaybackRate", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.setPlaybackRate", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "SetPlaybackRate", Err: err}
@@ -139,9 +147,9 @@ func (d *domainClient) SetPlaybackRate(ctx context.Context, args *SetPlaybackRat
 // node.
 func (d *domainClient) SetTiming(ctx context.Context, args *SetTimingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Animation.setTiming", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.setTiming", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Animation.setTiming", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Animation.setTiming", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Animation", Op: "SetTiming", Err: err}
@@ -150,7 +158,7 @@ func (d *domainClient) SetTiming(ctx context.Context, args *SetTimingArgs) (err 
 }
 
 func (d *domainClient) AnimationCanceled(ctx context.Context) (CanceledClient, error) {
-	s, err := rpcc.NewStream(ctx, "Animation.animationCanceled", d.conn)
+	s, err := rpcc.NewStream(ctx, "Animation.animationCanceled", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +179,7 @@ func (c *canceledClient) Recv() (*CanceledReply, error) {
 }
 
 func (d *domainClient) AnimationCreated(ctx context.Context) (CreatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Animation.animationCreated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Animation.animationCreated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +200,7 @@ func (c *createdClient) Recv() (*CreatedReply, error) {
 }
 
 func (d *domainClient) AnimationStarted(ctx context.Context) (StartedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Animation.animationStarted", d.conn)
+	s, err := rpcc.NewStream(ctx, "Animation.animationStarted", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/applicationcache/domain.go
+++ b/protocol/applicationcache/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the ApplicationCache domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the ApplicationCache domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the ApplicationCache domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Enable invokes the ApplicationCache method. Enables application cache
 // domain notifications.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "ApplicationCache.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "ApplicationCache.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "ApplicationCache", Op: "Enable", Err: err}
 	}
@@ -33,9 +41,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) GetApplicationCacheForFrame(ctx context.Context, args *GetApplicationCacheForFrameArgs) (reply *GetApplicationCacheForFrameReply, err error) {
 	reply = new(GetApplicationCacheForFrameReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ApplicationCache.getApplicationCacheForFrame", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ApplicationCache.getApplicationCacheForFrame", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ApplicationCache.getApplicationCacheForFrame", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ApplicationCache.getApplicationCacheForFrame", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ApplicationCache", Op: "GetApplicationCacheForFrame", Err: err}
@@ -48,7 +56,7 @@ func (d *domainClient) GetApplicationCacheForFrame(ctx context.Context, args *Ge
 // associated with some application cache.
 func (d *domainClient) GetFramesWithManifests(ctx context.Context) (reply *GetFramesWithManifestsReply, err error) {
 	reply = new(GetFramesWithManifestsReply)
-	err = rpcc.Invoke(ctx, "ApplicationCache.getFramesWithManifests", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "ApplicationCache.getFramesWithManifests", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "ApplicationCache", Op: "GetFramesWithManifests", Err: err}
 	}
@@ -60,9 +68,9 @@ func (d *domainClient) GetFramesWithManifests(ctx context.Context) (reply *GetFr
 func (d *domainClient) GetManifestForFrame(ctx context.Context, args *GetManifestForFrameArgs) (reply *GetManifestForFrameReply, err error) {
 	reply = new(GetManifestForFrameReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ApplicationCache.getManifestForFrame", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ApplicationCache.getManifestForFrame", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ApplicationCache.getManifestForFrame", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ApplicationCache.getManifestForFrame", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ApplicationCache", Op: "GetManifestForFrame", Err: err}
@@ -71,7 +79,7 @@ func (d *domainClient) GetManifestForFrame(ctx context.Context, args *GetManifes
 }
 
 func (d *domainClient) ApplicationCacheStatusUpdated(ctx context.Context) (StatusUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "ApplicationCache.applicationCacheStatusUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "ApplicationCache.applicationCacheStatusUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +100,7 @@ func (c *statusUpdatedClient) Recv() (*StatusUpdatedReply, error) {
 }
 
 func (d *domainClient) NetworkStateUpdated(ctx context.Context) (NetworkStateUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "ApplicationCache.networkStateUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "ApplicationCache.networkStateUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/audits/domain.go
+++ b/protocol/audits/domain.go
@@ -13,11 +13,19 @@ import (
 
 // domainClient is a client for the Audits domain. Audits domain allows
 // investigation of page violations and possible improvements.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Audits domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the Audits domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // GetEncodedResponse invokes the Audits method. Returns the response body and
@@ -26,9 +34,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) GetEncodedResponse(ctx context.Context, args *GetEncodedResponseArgs) (reply *GetEncodedResponseReply, err error) {
 	reply = new(GetEncodedResponseReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Audits.getEncodedResponse", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Audits.getEncodedResponse", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Audits.getEncodedResponse", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Audits.getEncodedResponse", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Audits", Op: "GetEncodedResponse", Err: err}

--- a/protocol/backgroundservice/domain.go
+++ b/protocol/backgroundservice/domain.go
@@ -13,20 +13,28 @@ import (
 
 // domainClient is a client for the BackgroundService domain. Defines events
 // for background web platform features.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the BackgroundService domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the BackgroundService domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // StartObserving invokes the BackgroundService method. Enables event updates
 // for the service.
 func (d *domainClient) StartObserving(ctx context.Context, args *StartObservingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "BackgroundService.startObserving", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.startObserving", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "BackgroundService.startObserving", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.startObserving", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "BackgroundService", Op: "StartObserving", Err: err}
@@ -38,9 +46,9 @@ func (d *domainClient) StartObserving(ctx context.Context, args *StartObservingA
 // for the service.
 func (d *domainClient) StopObserving(ctx context.Context, args *StopObservingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "BackgroundService.stopObserving", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.stopObserving", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "BackgroundService.stopObserving", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.stopObserving", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "BackgroundService", Op: "StopObserving", Err: err}
@@ -52,9 +60,9 @@ func (d *domainClient) StopObserving(ctx context.Context, args *StopObservingArg
 // for the service.
 func (d *domainClient) SetRecording(ctx context.Context, args *SetRecordingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "BackgroundService.setRecording", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.setRecording", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "BackgroundService.setRecording", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.setRecording", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "BackgroundService", Op: "SetRecording", Err: err}
@@ -66,9 +74,9 @@ func (d *domainClient) SetRecording(ctx context.Context, args *SetRecordingArgs)
 // for the service.
 func (d *domainClient) ClearEvents(ctx context.Context, args *ClearEventsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "BackgroundService.clearEvents", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.clearEvents", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "BackgroundService.clearEvents", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "BackgroundService.clearEvents", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "BackgroundService", Op: "ClearEvents", Err: err}
@@ -77,7 +85,7 @@ func (d *domainClient) ClearEvents(ctx context.Context, args *ClearEventsArgs) (
 }
 
 func (d *domainClient) RecordingStateChanged(ctx context.Context) (RecordingStateChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "BackgroundService.recordingStateChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "BackgroundService.recordingStateChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +106,7 @@ func (c *recordingStateChangedClient) Recv() (*RecordingStateChangedReply, error
 }
 
 func (d *domainClient) BackgroundServiceEventReceived(ctx context.Context) (EventReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "BackgroundService.backgroundServiceEventReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "BackgroundService.backgroundServiceEventReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/browser/domain.go
+++ b/protocol/browser/domain.go
@@ -13,20 +13,28 @@ import (
 
 // domainClient is a client for the Browser domain. The Browser domain defines
 // methods and events for browser managing.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Browser domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Browser domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // GrantPermissions invokes the Browser method. Grant specific permissions to
 // the given origin and reject all others.
 func (d *domainClient) GrantPermissions(ctx context.Context, args *GrantPermissionsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.grantPermissions", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.grantPermissions", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.grantPermissions", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.grantPermissions", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GrantPermissions", Err: err}
@@ -38,9 +46,9 @@ func (d *domainClient) GrantPermissions(ctx context.Context, args *GrantPermissi
 // management for all origins.
 func (d *domainClient) ResetPermissions(ctx context.Context, args *ResetPermissionsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.resetPermissions", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.resetPermissions", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.resetPermissions", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.resetPermissions", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "ResetPermissions", Err: err}
@@ -50,7 +58,7 @@ func (d *domainClient) ResetPermissions(ctx context.Context, args *ResetPermissi
 
 // Close invokes the Browser method. Close browser gracefully.
 func (d *domainClient) Close(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Browser.close", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Browser.close", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "Close", Err: err}
 	}
@@ -59,7 +67,7 @@ func (d *domainClient) Close(ctx context.Context) (err error) {
 
 // Crash invokes the Browser method. Crashes browser on the main thread.
 func (d *domainClient) Crash(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Browser.crash", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Browser.crash", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "Crash", Err: err}
 	}
@@ -68,7 +76,7 @@ func (d *domainClient) Crash(ctx context.Context) (err error) {
 
 // CrashGPUProcess invokes the Browser method. Crashes GPU process.
 func (d *domainClient) CrashGPUProcess(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Browser.crashGpuProcess", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Browser.crashGpuProcess", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "CrashGPUProcess", Err: err}
 	}
@@ -78,7 +86,7 @@ func (d *domainClient) CrashGPUProcess(ctx context.Context) (err error) {
 // GetVersion invokes the Browser method. Returns version information.
 func (d *domainClient) GetVersion(ctx context.Context) (reply *GetVersionReply, err error) {
 	reply = new(GetVersionReply)
-	err = rpcc.Invoke(ctx, "Browser.getVersion", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Browser.getVersion", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GetVersion", Err: err}
 	}
@@ -90,7 +98,7 @@ func (d *domainClient) GetVersion(ctx context.Context) (reply *GetVersionReply, 
 // the commandline.
 func (d *domainClient) GetBrowserCommandLine(ctx context.Context) (reply *GetBrowserCommandLineReply, err error) {
 	reply = new(GetBrowserCommandLineReply)
-	err = rpcc.Invoke(ctx, "Browser.getBrowserCommandLine", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Browser.getBrowserCommandLine", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GetBrowserCommandLine", Err: err}
 	}
@@ -101,9 +109,9 @@ func (d *domainClient) GetBrowserCommandLine(ctx context.Context) (reply *GetBro
 func (d *domainClient) GetHistograms(ctx context.Context, args *GetHistogramsArgs) (reply *GetHistogramsReply, err error) {
 	reply = new(GetHistogramsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.getHistograms", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getHistograms", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.getHistograms", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getHistograms", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GetHistograms", Err: err}
@@ -115,9 +123,9 @@ func (d *domainClient) GetHistograms(ctx context.Context, args *GetHistogramsArg
 func (d *domainClient) GetHistogram(ctx context.Context, args *GetHistogramArgs) (reply *GetHistogramReply, err error) {
 	reply = new(GetHistogramReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.getHistogram", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getHistogram", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.getHistogram", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getHistogram", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GetHistogram", Err: err}
@@ -130,9 +138,9 @@ func (d *domainClient) GetHistogram(ctx context.Context, args *GetHistogramArgs)
 func (d *domainClient) GetWindowBounds(ctx context.Context, args *GetWindowBoundsArgs) (reply *GetWindowBoundsReply, err error) {
 	reply = new(GetWindowBoundsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.getWindowBounds", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getWindowBounds", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.getWindowBounds", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getWindowBounds", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GetWindowBounds", Err: err}
@@ -145,9 +153,9 @@ func (d *domainClient) GetWindowBounds(ctx context.Context, args *GetWindowBound
 func (d *domainClient) GetWindowForTarget(ctx context.Context, args *GetWindowForTargetArgs) (reply *GetWindowForTargetReply, err error) {
 	reply = new(GetWindowForTargetReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.getWindowForTarget", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getWindowForTarget", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.getWindowForTarget", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.getWindowForTarget", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "GetWindowForTarget", Err: err}
@@ -159,9 +167,9 @@ func (d *domainClient) GetWindowForTarget(ctx context.Context, args *GetWindowFo
 // browser window.
 func (d *domainClient) SetWindowBounds(ctx context.Context, args *SetWindowBoundsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.setWindowBounds", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.setWindowBounds", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.setWindowBounds", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.setWindowBounds", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "SetWindowBounds", Err: err}
@@ -173,9 +181,9 @@ func (d *domainClient) SetWindowBounds(ctx context.Context, args *SetWindowBound
 // platform-specific.
 func (d *domainClient) SetDockTile(ctx context.Context, args *SetDockTileArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Browser.setDockTile", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.setDockTile", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Browser.setDockTile", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Browser.setDockTile", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Browser", Op: "SetDockTile", Err: err}

--- a/protocol/cachestorage/domain.go
+++ b/protocol/cachestorage/domain.go
@@ -11,19 +11,27 @@ import (
 )
 
 // domainClient is a client for the CacheStorage domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the CacheStorage domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the CacheStorage domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // DeleteCache invokes the CacheStorage method. Deletes a cache.
 func (d *domainClient) DeleteCache(ctx context.Context, args *DeleteCacheArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CacheStorage.deleteCache", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.deleteCache", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CacheStorage.deleteCache", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.deleteCache", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CacheStorage", Op: "DeleteCache", Err: err}
@@ -34,9 +42,9 @@ func (d *domainClient) DeleteCache(ctx context.Context, args *DeleteCacheArgs) (
 // DeleteEntry invokes the CacheStorage method. Deletes a cache entry.
 func (d *domainClient) DeleteEntry(ctx context.Context, args *DeleteEntryArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CacheStorage.deleteEntry", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.deleteEntry", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CacheStorage.deleteEntry", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.deleteEntry", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CacheStorage", Op: "DeleteEntry", Err: err}
@@ -48,9 +56,9 @@ func (d *domainClient) DeleteEntry(ctx context.Context, args *DeleteEntryArgs) (
 func (d *domainClient) RequestCacheNames(ctx context.Context, args *RequestCacheNamesArgs) (reply *RequestCacheNamesReply, err error) {
 	reply = new(RequestCacheNamesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CacheStorage.requestCacheNames", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.requestCacheNames", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CacheStorage.requestCacheNames", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.requestCacheNames", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CacheStorage", Op: "RequestCacheNames", Err: err}
@@ -62,9 +70,9 @@ func (d *domainClient) RequestCacheNames(ctx context.Context, args *RequestCache
 func (d *domainClient) RequestCachedResponse(ctx context.Context, args *RequestCachedResponseArgs) (reply *RequestCachedResponseReply, err error) {
 	reply = new(RequestCachedResponseReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CacheStorage.requestCachedResponse", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.requestCachedResponse", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CacheStorage.requestCachedResponse", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.requestCachedResponse", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CacheStorage", Op: "RequestCachedResponse", Err: err}
@@ -76,9 +84,9 @@ func (d *domainClient) RequestCachedResponse(ctx context.Context, args *RequestC
 func (d *domainClient) RequestEntries(ctx context.Context, args *RequestEntriesArgs) (reply *RequestEntriesReply, err error) {
 	reply = new(RequestEntriesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CacheStorage.requestEntries", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.requestEntries", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CacheStorage.requestEntries", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CacheStorage.requestEntries", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CacheStorage", Op: "RequestEntries", Err: err}

--- a/protocol/cast/domain.go
+++ b/protocol/cast/domain.go
@@ -13,11 +13,19 @@ import (
 
 // domainClient is a client for the Cast domain. A domain for interacting with
 // Cast, Presentation API, and Remote Playback API functionalities.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Cast domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the Cast domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // Enable invokes the Cast method. Starts observing for sinks that can be used
@@ -27,9 +35,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 // |issueUpdated| event is fired.
 func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Cast.enable", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.enable", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Cast.enable", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.enable", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Cast", Op: "Enable", Err: err}
@@ -39,7 +47,7 @@ func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (err error)
 
 // Disable invokes the Cast method. Stops observing for sinks and issues.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Cast.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Cast.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Cast", Op: "Disable", Err: err}
 	}
@@ -51,9 +59,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Playback API, or Cast SDK.
 func (d *domainClient) SetSinkToUse(ctx context.Context, args *SetSinkToUseArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Cast.setSinkToUse", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.setSinkToUse", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Cast.setSinkToUse", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.setSinkToUse", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Cast", Op: "SetSinkToUse", Err: err}
@@ -65,9 +73,9 @@ func (d *domainClient) SetSinkToUse(ctx context.Context, args *SetSinkToUseArgs)
 // sink.
 func (d *domainClient) StartTabMirroring(ctx context.Context, args *StartTabMirroringArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Cast.startTabMirroring", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.startTabMirroring", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Cast.startTabMirroring", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.startTabMirroring", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Cast", Op: "StartTabMirroring", Err: err}
@@ -79,9 +87,9 @@ func (d *domainClient) StartTabMirroring(ctx context.Context, args *StartTabMirr
 // sink.
 func (d *domainClient) StopCasting(ctx context.Context, args *StopCastingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Cast.stopCasting", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.stopCasting", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Cast.stopCasting", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Cast.stopCasting", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Cast", Op: "StopCasting", Err: err}
@@ -90,7 +98,7 @@ func (d *domainClient) StopCasting(ctx context.Context, args *StopCastingArgs) (
 }
 
 func (d *domainClient) SinksUpdated(ctx context.Context) (SinksUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Cast.sinksUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Cast.sinksUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +119,7 @@ func (c *sinksUpdatedClient) Recv() (*SinksUpdatedReply, error) {
 }
 
 func (d *domainClient) IssueUpdated(ctx context.Context) (IssueUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Cast.issueUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Cast.issueUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/console/domain.go
+++ b/protocol/console/domain.go
@@ -13,16 +13,24 @@ import (
 
 // domainClient is a client for the Console domain. This domain is deprecated
 // - use Runtime or Log instead.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Console domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Console domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // ClearMessages invokes the Console method. Does nothing.
 func (d *domainClient) ClearMessages(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Console.clearMessages", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Console.clearMessages", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Console", Op: "ClearMessages", Err: err}
 	}
@@ -32,7 +40,7 @@ func (d *domainClient) ClearMessages(ctx context.Context) (err error) {
 // Disable invokes the Console method. Disables console domain, prevents
 // further console messages from being reported to the client.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Console.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Console.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Console", Op: "Disable", Err: err}
 	}
@@ -43,7 +51,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // messages collected so far to the client by means of the `messageAdded`
 // notification.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Console.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Console.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Console", Op: "Enable", Err: err}
 	}
@@ -51,7 +59,7 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 }
 
 func (d *domainClient) MessageAdded(ctx context.Context) (MessageAddedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Console.messageAdded", d.conn)
+	s, err := rpcc.NewStream(ctx, "Console.messageAdded", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/css/domain.go
+++ b/protocol/css/domain.go
@@ -27,11 +27,19 @@ import (
 // track of stylesheets via the `styleSheetAdded`/`styleSheetRemoved` events
 // and subsequently load the required stylesheet contents using the
 // `getStyleSheet[Text]()` methods.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the CSS domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the CSS domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // AddRule invokes the CSS method. Inserts a new rule with the given
@@ -40,9 +48,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) AddRule(ctx context.Context, args *AddRuleArgs) (reply *AddRuleReply, err error) {
 	reply = new(AddRuleReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.addRule", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.addRule", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.addRule", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.addRule", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "AddRule", Err: err}
@@ -55,9 +63,9 @@ func (d *domainClient) AddRule(ctx context.Context, args *AddRuleArgs) (reply *A
 func (d *domainClient) CollectClassNames(ctx context.Context, args *CollectClassNamesArgs) (reply *CollectClassNamesReply, err error) {
 	reply = new(CollectClassNamesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.collectClassNames", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.collectClassNames", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.collectClassNames", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.collectClassNames", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "CollectClassNames", Err: err}
@@ -70,9 +78,9 @@ func (d *domainClient) CollectClassNames(ctx context.Context, args *CollectClass
 func (d *domainClient) CreateStyleSheet(ctx context.Context, args *CreateStyleSheetArgs) (reply *CreateStyleSheetReply, err error) {
 	reply = new(CreateStyleSheetReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.createStyleSheet", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.createStyleSheet", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.createStyleSheet", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.createStyleSheet", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "CreateStyleSheet", Err: err}
@@ -82,7 +90,7 @@ func (d *domainClient) CreateStyleSheet(ctx context.Context, args *CreateStyleSh
 
 // Disable invokes the CSS method. Disables the CSS agent for the given page.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "CSS.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "CSS.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "Disable", Err: err}
 	}
@@ -93,7 +101,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Clients should not assume that the CSS agent has been enabled until the
 // result of this command is received.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "CSS.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "CSS.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "Enable", Err: err}
 	}
@@ -104,9 +112,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // have specified pseudo-classes whenever its style is computed by the browser.
 func (d *domainClient) ForcePseudoState(ctx context.Context, args *ForcePseudoStateArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.forcePseudoState", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.forcePseudoState", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.forcePseudoState", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.forcePseudoState", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "ForcePseudoState", Err: err}
@@ -118,9 +126,9 @@ func (d *domainClient) ForcePseudoState(ctx context.Context, args *ForcePseudoSt
 func (d *domainClient) GetBackgroundColors(ctx context.Context, args *GetBackgroundColorsArgs) (reply *GetBackgroundColorsReply, err error) {
 	reply = new(GetBackgroundColorsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.getBackgroundColors", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getBackgroundColors", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.getBackgroundColors", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getBackgroundColors", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetBackgroundColors", Err: err}
@@ -133,9 +141,9 @@ func (d *domainClient) GetBackgroundColors(ctx context.Context, args *GetBackgro
 func (d *domainClient) GetComputedStyleForNode(ctx context.Context, args *GetComputedStyleForNodeArgs) (reply *GetComputedStyleForNodeReply, err error) {
 	reply = new(GetComputedStyleForNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.getComputedStyleForNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getComputedStyleForNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.getComputedStyleForNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getComputedStyleForNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetComputedStyleForNode", Err: err}
@@ -149,9 +157,9 @@ func (d *domainClient) GetComputedStyleForNode(ctx context.Context, args *GetCom
 func (d *domainClient) GetInlineStylesForNode(ctx context.Context, args *GetInlineStylesForNodeArgs) (reply *GetInlineStylesForNodeReply, err error) {
 	reply = new(GetInlineStylesForNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.getInlineStylesForNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getInlineStylesForNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.getInlineStylesForNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getInlineStylesForNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetInlineStylesForNode", Err: err}
@@ -164,9 +172,9 @@ func (d *domainClient) GetInlineStylesForNode(ctx context.Context, args *GetInli
 func (d *domainClient) GetMatchedStylesForNode(ctx context.Context, args *GetMatchedStylesForNodeArgs) (reply *GetMatchedStylesForNodeReply, err error) {
 	reply = new(GetMatchedStylesForNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.getMatchedStylesForNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getMatchedStylesForNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.getMatchedStylesForNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getMatchedStylesForNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetMatchedStylesForNode", Err: err}
@@ -178,7 +186,7 @@ func (d *domainClient) GetMatchedStylesForNode(ctx context.Context, args *GetMat
 // the rendering engine.
 func (d *domainClient) GetMediaQueries(ctx context.Context) (reply *GetMediaQueriesReply, err error) {
 	reply = new(GetMediaQueriesReply)
-	err = rpcc.Invoke(ctx, "CSS.getMediaQueries", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "CSS.getMediaQueries", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetMediaQueries", Err: err}
 	}
@@ -190,9 +198,9 @@ func (d *domainClient) GetMediaQueries(ctx context.Context) (reply *GetMediaQuer
 func (d *domainClient) GetPlatformFontsForNode(ctx context.Context, args *GetPlatformFontsForNodeArgs) (reply *GetPlatformFontsForNodeReply, err error) {
 	reply = new(GetPlatformFontsForNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.getPlatformFontsForNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getPlatformFontsForNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.getPlatformFontsForNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getPlatformFontsForNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetPlatformFontsForNode", Err: err}
@@ -205,9 +213,9 @@ func (d *domainClient) GetPlatformFontsForNode(ctx context.Context, args *GetPla
 func (d *domainClient) GetStyleSheetText(ctx context.Context, args *GetStyleSheetTextArgs) (reply *GetStyleSheetTextReply, err error) {
 	reply = new(GetStyleSheetTextReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.getStyleSheetText", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getStyleSheetText", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.getStyleSheetText", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.getStyleSheetText", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "GetStyleSheetText", Err: err}
@@ -220,9 +228,9 @@ func (d *domainClient) GetStyleSheetText(ctx context.Context, args *GetStyleShee
 // property
 func (d *domainClient) SetEffectivePropertyValueForNode(ctx context.Context, args *SetEffectivePropertyValueForNodeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.setEffectivePropertyValueForNode", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setEffectivePropertyValueForNode", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.setEffectivePropertyValueForNode", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setEffectivePropertyValueForNode", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "SetEffectivePropertyValueForNode", Err: err}
@@ -234,9 +242,9 @@ func (d *domainClient) SetEffectivePropertyValueForNode(ctx context.Context, arg
 func (d *domainClient) SetKeyframeKey(ctx context.Context, args *SetKeyframeKeyArgs) (reply *SetKeyframeKeyReply, err error) {
 	reply = new(SetKeyframeKeyReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.setKeyframeKey", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setKeyframeKey", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.setKeyframeKey", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setKeyframeKey", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "SetKeyframeKey", Err: err}
@@ -248,9 +256,9 @@ func (d *domainClient) SetKeyframeKey(ctx context.Context, args *SetKeyframeKeyA
 func (d *domainClient) SetMediaText(ctx context.Context, args *SetMediaTextArgs) (reply *SetMediaTextReply, err error) {
 	reply = new(SetMediaTextReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.setMediaText", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setMediaText", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.setMediaText", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setMediaText", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "SetMediaText", Err: err}
@@ -262,9 +270,9 @@ func (d *domainClient) SetMediaText(ctx context.Context, args *SetMediaTextArgs)
 func (d *domainClient) SetRuleSelector(ctx context.Context, args *SetRuleSelectorArgs) (reply *SetRuleSelectorReply, err error) {
 	reply = new(SetRuleSelectorReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.setRuleSelector", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setRuleSelector", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.setRuleSelector", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setRuleSelector", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "SetRuleSelector", Err: err}
@@ -276,9 +284,9 @@ func (d *domainClient) SetRuleSelector(ctx context.Context, args *SetRuleSelecto
 func (d *domainClient) SetStyleSheetText(ctx context.Context, args *SetStyleSheetTextArgs) (reply *SetStyleSheetTextReply, err error) {
 	reply = new(SetStyleSheetTextReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.setStyleSheetText", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setStyleSheetText", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.setStyleSheetText", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setStyleSheetText", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "SetStyleSheetText", Err: err}
@@ -291,9 +299,9 @@ func (d *domainClient) SetStyleSheetText(ctx context.Context, args *SetStyleShee
 func (d *domainClient) SetStyleTexts(ctx context.Context, args *SetStyleTextsArgs) (reply *SetStyleTextsReply, err error) {
 	reply = new(SetStyleTextsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "CSS.setStyleTexts", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setStyleTexts", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "CSS.setStyleTexts", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "CSS.setStyleTexts", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "SetStyleTexts", Err: err}
@@ -304,7 +312,7 @@ func (d *domainClient) SetStyleTexts(ctx context.Context, args *SetStyleTextsArg
 // StartRuleUsageTracking invokes the CSS method. Enables the selector
 // recording.
 func (d *domainClient) StartRuleUsageTracking(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "CSS.startRuleUsageTracking", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "CSS.startRuleUsageTracking", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "StartRuleUsageTracking", Err: err}
 	}
@@ -316,7 +324,7 @@ func (d *domainClient) StartRuleUsageTracking(ctx context.Context) (err error) {
 // `takeCoverageDelta` (or since start of coverage instrumentation)
 func (d *domainClient) StopRuleUsageTracking(ctx context.Context) (reply *StopRuleUsageTrackingReply, err error) {
 	reply = new(StopRuleUsageTrackingReply)
-	err = rpcc.Invoke(ctx, "CSS.stopRuleUsageTracking", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "CSS.stopRuleUsageTracking", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "StopRuleUsageTracking", Err: err}
 	}
@@ -328,7 +336,7 @@ func (d *domainClient) StopRuleUsageTracking(ctx context.Context) (reply *StopRu
 // instrumentation)
 func (d *domainClient) TakeCoverageDelta(ctx context.Context) (reply *TakeCoverageDeltaReply, err error) {
 	reply = new(TakeCoverageDeltaReply)
-	err = rpcc.Invoke(ctx, "CSS.takeCoverageDelta", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "CSS.takeCoverageDelta", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "CSS", Op: "TakeCoverageDelta", Err: err}
 	}
@@ -336,7 +344,7 @@ func (d *domainClient) TakeCoverageDelta(ctx context.Context) (reply *TakeCovera
 }
 
 func (d *domainClient) FontsUpdated(ctx context.Context) (FontsUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "CSS.fontsUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "CSS.fontsUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +365,7 @@ func (c *fontsUpdatedClient) Recv() (*FontsUpdatedReply, error) {
 }
 
 func (d *domainClient) MediaQueryResultChanged(ctx context.Context) (MediaQueryResultChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "CSS.mediaQueryResultChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "CSS.mediaQueryResultChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +386,7 @@ func (c *mediaQueryResultChangedClient) Recv() (*MediaQueryResultChangedReply, e
 }
 
 func (d *domainClient) StyleSheetAdded(ctx context.Context) (StyleSheetAddedClient, error) {
-	s, err := rpcc.NewStream(ctx, "CSS.styleSheetAdded", d.conn)
+	s, err := rpcc.NewStream(ctx, "CSS.styleSheetAdded", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +407,7 @@ func (c *styleSheetAddedClient) Recv() (*StyleSheetAddedReply, error) {
 }
 
 func (d *domainClient) StyleSheetChanged(ctx context.Context) (StyleSheetChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "CSS.styleSheetChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "CSS.styleSheetChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +428,7 @@ func (c *styleSheetChangedClient) Recv() (*StyleSheetChangedReply, error) {
 }
 
 func (d *domainClient) StyleSheetRemoved(ctx context.Context) (StyleSheetRemovedClient, error) {
-	s, err := rpcc.NewStream(ctx, "CSS.styleSheetRemoved", d.conn)
+	s, err := rpcc.NewStream(ctx, "CSS.styleSheetRemoved", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/debugger/domain.go
+++ b/protocol/debugger/domain.go
@@ -15,20 +15,28 @@ import (
 // domainClient is a client for the Debugger domain. Debugger domain exposes
 // JavaScript debugging capabilities. It allows setting and removing
 // breakpoints, stepping through execution, exploring stack traces, etc.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Debugger domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Debugger domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // ContinueToLocation invokes the Debugger method. Continues execution until
 // specific location is reached.
 func (d *domainClient) ContinueToLocation(ctx context.Context, args *ContinueToLocationArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.continueToLocation", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.continueToLocation", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.continueToLocation", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.continueToLocation", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "ContinueToLocation", Err: err}
@@ -38,7 +46,7 @@ func (d *domainClient) ContinueToLocation(ctx context.Context, args *ContinueToL
 
 // Disable invokes the Debugger method. Disables debugger for given page.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Debugger.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Debugger.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "Disable", Err: err}
 	}
@@ -51,9 +59,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (reply *EnableReply, err error) {
 	reply = new(EnableReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.enable", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.enable", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.enable", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.enable", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "Enable", Err: err}
@@ -66,9 +74,9 @@ func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (reply *Ena
 func (d *domainClient) EvaluateOnCallFrame(ctx context.Context, args *EvaluateOnCallFrameArgs) (reply *EvaluateOnCallFrameReply, err error) {
 	reply = new(EvaluateOnCallFrameReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.evaluateOnCallFrame", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.evaluateOnCallFrame", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.evaluateOnCallFrame", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.evaluateOnCallFrame", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "EvaluateOnCallFrame", Err: err}
@@ -82,9 +90,9 @@ func (d *domainClient) EvaluateOnCallFrame(ctx context.Context, args *EvaluateOn
 func (d *domainClient) GetPossibleBreakpoints(ctx context.Context, args *GetPossibleBreakpointsArgs) (reply *GetPossibleBreakpointsReply, err error) {
 	reply = new(GetPossibleBreakpointsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.getPossibleBreakpoints", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.getPossibleBreakpoints", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.getPossibleBreakpoints", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.getPossibleBreakpoints", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "GetPossibleBreakpoints", Err: err}
@@ -97,9 +105,9 @@ func (d *domainClient) GetPossibleBreakpoints(ctx context.Context, args *GetPoss
 func (d *domainClient) GetScriptSource(ctx context.Context, args *GetScriptSourceArgs) (reply *GetScriptSourceReply, err error) {
 	reply = new(GetScriptSourceReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.getScriptSource", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.getScriptSource", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.getScriptSource", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.getScriptSource", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "GetScriptSource", Err: err}
@@ -112,9 +120,9 @@ func (d *domainClient) GetScriptSource(ctx context.Context, args *GetScriptSourc
 func (d *domainClient) GetStackTrace(ctx context.Context, args *GetStackTraceArgs) (reply *GetStackTraceReply, err error) {
 	reply = new(GetStackTraceReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.getStackTrace", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.getStackTrace", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.getStackTrace", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.getStackTrace", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "GetStackTrace", Err: err}
@@ -124,7 +132,7 @@ func (d *domainClient) GetStackTrace(ctx context.Context, args *GetStackTraceArg
 
 // Pause invokes the Debugger method. Stops on the next JavaScript statement.
 func (d *domainClient) Pause(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Debugger.pause", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Debugger.pause", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "Pause", Err: err}
 	}
@@ -134,9 +142,9 @@ func (d *domainClient) Pause(ctx context.Context) (err error) {
 // PauseOnAsyncCall invokes the Debugger method.
 func (d *domainClient) PauseOnAsyncCall(ctx context.Context, args *PauseOnAsyncCallArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.pauseOnAsyncCall", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.pauseOnAsyncCall", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.pauseOnAsyncCall", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.pauseOnAsyncCall", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "PauseOnAsyncCall", Err: err}
@@ -148,9 +156,9 @@ func (d *domainClient) PauseOnAsyncCall(ctx context.Context, args *PauseOnAsyncC
 // breakpoint.
 func (d *domainClient) RemoveBreakpoint(ctx context.Context, args *RemoveBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.removeBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.removeBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.removeBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.removeBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "RemoveBreakpoint", Err: err}
@@ -163,9 +171,9 @@ func (d *domainClient) RemoveBreakpoint(ctx context.Context, args *RemoveBreakpo
 func (d *domainClient) RestartFrame(ctx context.Context, args *RestartFrameArgs) (reply *RestartFrameReply, err error) {
 	reply = new(RestartFrameReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.restartFrame", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.restartFrame", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.restartFrame", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.restartFrame", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "RestartFrame", Err: err}
@@ -175,7 +183,7 @@ func (d *domainClient) RestartFrame(ctx context.Context, args *RestartFrameArgs)
 
 // Resume invokes the Debugger method. Resumes JavaScript execution.
 func (d *domainClient) Resume(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Debugger.resume", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Debugger.resume", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "Resume", Err: err}
 	}
@@ -187,9 +195,9 @@ func (d *domainClient) Resume(ctx context.Context) (err error) {
 func (d *domainClient) SearchInContent(ctx context.Context, args *SearchInContentArgs) (reply *SearchInContentReply, err error) {
 	reply = new(SearchInContentReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.searchInContent", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.searchInContent", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.searchInContent", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.searchInContent", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SearchInContent", Err: err}
@@ -201,9 +209,9 @@ func (d *domainClient) SearchInContent(ctx context.Context, args *SearchInConten
 // async call stacks tracking.
 func (d *domainClient) SetAsyncCallStackDepth(ctx context.Context, args *SetAsyncCallStackDepthArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setAsyncCallStackDepth", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setAsyncCallStackDepth", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setAsyncCallStackDepth", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setAsyncCallStackDepth", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetAsyncCallStackDepth", Err: err}
@@ -218,9 +226,9 @@ func (d *domainClient) SetAsyncCallStackDepth(ctx context.Context, args *SetAsyn
 // to 'step out' if unsuccessful.
 func (d *domainClient) SetBlackboxPatterns(ctx context.Context, args *SetBlackboxPatternsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setBlackboxPatterns", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBlackboxPatterns", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setBlackboxPatterns", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBlackboxPatterns", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetBlackboxPatterns", Err: err}
@@ -235,9 +243,9 @@ func (d *domainClient) SetBlackboxPatterns(ctx context.Context, args *SetBlackbo
 // changed. First interval isn't blackboxed. Array should be sorted.
 func (d *domainClient) SetBlackboxedRanges(ctx context.Context, args *SetBlackboxedRangesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setBlackboxedRanges", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBlackboxedRanges", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setBlackboxedRanges", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBlackboxedRanges", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetBlackboxedRanges", Err: err}
@@ -250,9 +258,9 @@ func (d *domainClient) SetBlackboxedRanges(ctx context.Context, args *SetBlackbo
 func (d *domainClient) SetBreakpoint(ctx context.Context, args *SetBreakpointArgs) (reply *SetBreakpointReply, err error) {
 	reply = new(SetBreakpointReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpoint", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpoint", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpoint", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpoint", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetBreakpoint", Err: err}
@@ -265,9 +273,9 @@ func (d *domainClient) SetBreakpoint(ctx context.Context, args *SetBreakpointArg
 func (d *domainClient) SetInstrumentationBreakpoint(ctx context.Context, args *SetInstrumentationBreakpointArgs) (reply *SetInstrumentationBreakpointReply, err error) {
 	reply = new(SetInstrumentationBreakpointReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setInstrumentationBreakpoint", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setInstrumentationBreakpoint", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setInstrumentationBreakpoint", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setInstrumentationBreakpoint", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetInstrumentationBreakpoint", Err: err}
@@ -284,9 +292,9 @@ func (d *domainClient) SetInstrumentationBreakpoint(ctx context.Context, args *S
 func (d *domainClient) SetBreakpointByURL(ctx context.Context, args *SetBreakpointByURLArgs) (reply *SetBreakpointByURLReply, err error) {
 	reply = new(SetBreakpointByURLReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpointByUrl", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpointByUrl", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpointByUrl", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpointByUrl", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetBreakpointByURL", Err: err}
@@ -301,9 +309,9 @@ func (d *domainClient) SetBreakpointByURL(ctx context.Context, args *SetBreakpoi
 func (d *domainClient) SetBreakpointOnFunctionCall(ctx context.Context, args *SetBreakpointOnFunctionCallArgs) (reply *SetBreakpointOnFunctionCallReply, err error) {
 	reply = new(SetBreakpointOnFunctionCallReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpointOnFunctionCall", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpointOnFunctionCall", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpointOnFunctionCall", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpointOnFunctionCall", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetBreakpointOnFunctionCall", Err: err}
@@ -315,9 +323,9 @@ func (d *domainClient) SetBreakpointOnFunctionCall(ctx context.Context, args *Se
 // all breakpoints on the page.
 func (d *domainClient) SetBreakpointsActive(ctx context.Context, args *SetBreakpointsActiveArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpointsActive", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpointsActive", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setBreakpointsActive", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setBreakpointsActive", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetBreakpointsActive", Err: err}
@@ -330,9 +338,9 @@ func (d *domainClient) SetBreakpointsActive(ctx context.Context, args *SetBreakp
 // or no exceptions. Initial pause on exceptions state is `none`.
 func (d *domainClient) SetPauseOnExceptions(ctx context.Context, args *SetPauseOnExceptionsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setPauseOnExceptions", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setPauseOnExceptions", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setPauseOnExceptions", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setPauseOnExceptions", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetPauseOnExceptions", Err: err}
@@ -344,9 +352,9 @@ func (d *domainClient) SetPauseOnExceptions(ctx context.Context, args *SetPauseO
 // frame. Available only at return break position.
 func (d *domainClient) SetReturnValue(ctx context.Context, args *SetReturnValueArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setReturnValue", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setReturnValue", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setReturnValue", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setReturnValue", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetReturnValue", Err: err}
@@ -358,9 +366,9 @@ func (d *domainClient) SetReturnValue(ctx context.Context, args *SetReturnValueA
 func (d *domainClient) SetScriptSource(ctx context.Context, args *SetScriptSourceArgs) (reply *SetScriptSourceReply, err error) {
 	reply = new(SetScriptSourceReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setScriptSource", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setScriptSource", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setScriptSource", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setScriptSource", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetScriptSource", Err: err}
@@ -372,9 +380,9 @@ func (d *domainClient) SetScriptSource(ctx context.Context, args *SetScriptSourc
 // any pauses (breakpoint, exception, dom exception etc).
 func (d *domainClient) SetSkipAllPauses(ctx context.Context, args *SetSkipAllPausesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setSkipAllPauses", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setSkipAllPauses", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setSkipAllPauses", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setSkipAllPauses", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetSkipAllPauses", Err: err}
@@ -387,9 +395,9 @@ func (d *domainClient) SetSkipAllPauses(ctx context.Context, args *SetSkipAllPau
 // manually.
 func (d *domainClient) SetVariableValue(ctx context.Context, args *SetVariableValueArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.setVariableValue", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setVariableValue", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.setVariableValue", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.setVariableValue", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "SetVariableValue", Err: err}
@@ -400,9 +408,9 @@ func (d *domainClient) SetVariableValue(ctx context.Context, args *SetVariableVa
 // StepInto invokes the Debugger method. Steps into the function call.
 func (d *domainClient) StepInto(ctx context.Context, args *StepIntoArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Debugger.stepInto", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.stepInto", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Debugger.stepInto", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Debugger.stepInto", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "StepInto", Err: err}
@@ -412,7 +420,7 @@ func (d *domainClient) StepInto(ctx context.Context, args *StepIntoArgs) (err er
 
 // StepOut invokes the Debugger method. Steps out of the function call.
 func (d *domainClient) StepOut(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Debugger.stepOut", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Debugger.stepOut", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "StepOut", Err: err}
 	}
@@ -421,7 +429,7 @@ func (d *domainClient) StepOut(ctx context.Context) (err error) {
 
 // StepOver invokes the Debugger method. Steps over the statement.
 func (d *domainClient) StepOver(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Debugger.stepOver", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Debugger.stepOver", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Debugger", Op: "StepOver", Err: err}
 	}
@@ -429,7 +437,7 @@ func (d *domainClient) StepOver(ctx context.Context) (err error) {
 }
 
 func (d *domainClient) BreakpointResolved(ctx context.Context) (BreakpointResolvedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Debugger.breakpointResolved", d.conn)
+	s, err := rpcc.NewStream(ctx, "Debugger.breakpointResolved", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +458,7 @@ func (c *breakpointResolvedClient) Recv() (*BreakpointResolvedReply, error) {
 }
 
 func (d *domainClient) Paused(ctx context.Context) (PausedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Debugger.paused", d.conn)
+	s, err := rpcc.NewStream(ctx, "Debugger.paused", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +479,7 @@ func (c *pausedClient) Recv() (*PausedReply, error) {
 }
 
 func (d *domainClient) Resumed(ctx context.Context) (ResumedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Debugger.resumed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Debugger.resumed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +500,7 @@ func (c *resumedClient) Recv() (*ResumedReply, error) {
 }
 
 func (d *domainClient) ScriptFailedToParse(ctx context.Context) (ScriptFailedToParseClient, error) {
-	s, err := rpcc.NewStream(ctx, "Debugger.scriptFailedToParse", d.conn)
+	s, err := rpcc.NewStream(ctx, "Debugger.scriptFailedToParse", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +521,7 @@ func (c *scriptFailedToParseClient) Recv() (*ScriptFailedToParseReply, error) {
 }
 
 func (d *domainClient) ScriptParsed(ctx context.Context) (ScriptParsedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Debugger.scriptParsed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Debugger.scriptParsed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/deviceorientation/domain.go
+++ b/protocol/deviceorientation/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the DeviceOrientation domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the DeviceOrientation domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the DeviceOrientation domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // ClearDeviceOrientationOverride invokes the DeviceOrientation method. Clears
 // the overridden Device Orientation.
 func (d *domainClient) ClearDeviceOrientationOverride(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DeviceOrientation.clearDeviceOrientationOverride", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DeviceOrientation.clearDeviceOrientationOverride", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DeviceOrientation", Op: "ClearDeviceOrientationOverride", Err: err}
 	}
@@ -32,9 +40,9 @@ func (d *domainClient) ClearDeviceOrientationOverride(ctx context.Context) (err 
 // Overrides the Device Orientation.
 func (d *domainClient) SetDeviceOrientationOverride(ctx context.Context, args *SetDeviceOrientationOverrideArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DeviceOrientation.setDeviceOrientationOverride", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DeviceOrientation.setDeviceOrientationOverride", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DeviceOrientation.setDeviceOrientationOverride", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DeviceOrientation.setDeviceOrientationOverride", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DeviceOrientation", Op: "SetDeviceOrientationOverride", Err: err}

--- a/protocol/dom/domain.go
+++ b/protocol/dom/domain.go
@@ -31,11 +31,19 @@ import (
 //
 // Note that `iframe` owner elements will return corresponding document
 // elements as their child nodes.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the DOM domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the DOM domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // CollectClassNamesFromSubtree invokes the DOM method. Collects class names
@@ -43,9 +51,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) CollectClassNamesFromSubtree(ctx context.Context, args *CollectClassNamesFromSubtreeArgs) (reply *CollectClassNamesFromSubtreeReply, err error) {
 	reply = new(CollectClassNamesFromSubtreeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.collectClassNamesFromSubtree", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.collectClassNamesFromSubtree", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.collectClassNamesFromSubtree", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.collectClassNamesFromSubtree", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "CollectClassNamesFromSubtree", Err: err}
@@ -58,9 +66,9 @@ func (d *domainClient) CollectClassNamesFromSubtree(ctx context.Context, args *C
 func (d *domainClient) CopyTo(ctx context.Context, args *CopyToArgs) (reply *CopyToReply, err error) {
 	reply = new(CopyToReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.copyTo", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.copyTo", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.copyTo", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.copyTo", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "CopyTo", Err: err}
@@ -74,9 +82,9 @@ func (d *domainClient) CopyTo(ctx context.Context, args *CopyToArgs) (reply *Cop
 func (d *domainClient) DescribeNode(ctx context.Context, args *DescribeNodeArgs) (reply *DescribeNodeReply, err error) {
 	reply = new(DescribeNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.describeNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.describeNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.describeNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.describeNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "DescribeNode", Err: err}
@@ -86,7 +94,7 @@ func (d *domainClient) DescribeNode(ctx context.Context, args *DescribeNodeArgs)
 
 // Disable invokes the DOM method. Disables DOM agent for the given page.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOM.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOM.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "Disable", Err: err}
 	}
@@ -98,9 +106,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // for that search.
 func (d *domainClient) DiscardSearchResults(ctx context.Context, args *DiscardSearchResultsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.discardSearchResults", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.discardSearchResults", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.discardSearchResults", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.discardSearchResults", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "DiscardSearchResults", Err: err}
@@ -110,7 +118,7 @@ func (d *domainClient) DiscardSearchResults(ctx context.Context, args *DiscardSe
 
 // Enable invokes the DOM method. Enables DOM agent for the given page.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOM.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOM.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "Enable", Err: err}
 	}
@@ -120,9 +128,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // Focus invokes the DOM method. Focuses the given element.
 func (d *domainClient) Focus(ctx context.Context, args *FocusArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.focus", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.focus", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.focus", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.focus", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "Focus", Err: err}
@@ -135,9 +143,9 @@ func (d *domainClient) Focus(ctx context.Context, args *FocusArgs) (err error) {
 func (d *domainClient) GetAttributes(ctx context.Context, args *GetAttributesArgs) (reply *GetAttributesReply, err error) {
 	reply = new(GetAttributesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getAttributes", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getAttributes", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getAttributes", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getAttributes", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetAttributes", Err: err}
@@ -149,9 +157,9 @@ func (d *domainClient) GetAttributes(ctx context.Context, args *GetAttributesArg
 func (d *domainClient) GetBoxModel(ctx context.Context, args *GetBoxModelArgs) (reply *GetBoxModelReply, err error) {
 	reply = new(GetBoxModelReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getBoxModel", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getBoxModel", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getBoxModel", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getBoxModel", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetBoxModel", Err: err}
@@ -165,9 +173,9 @@ func (d *domainClient) GetBoxModel(ctx context.Context, args *GetBoxModelArgs) (
 func (d *domainClient) GetContentQuads(ctx context.Context, args *GetContentQuadsArgs) (reply *GetContentQuadsReply, err error) {
 	reply = new(GetContentQuadsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getContentQuads", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getContentQuads", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getContentQuads", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getContentQuads", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetContentQuads", Err: err}
@@ -180,9 +188,9 @@ func (d *domainClient) GetContentQuads(ctx context.Context, args *GetContentQuad
 func (d *domainClient) GetDocument(ctx context.Context, args *GetDocumentArgs) (reply *GetDocumentReply, err error) {
 	reply = new(GetDocumentReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getDocument", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getDocument", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getDocument", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getDocument", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetDocument", Err: err}
@@ -195,9 +203,9 @@ func (d *domainClient) GetDocument(ctx context.Context, args *GetDocumentArgs) (
 func (d *domainClient) GetFlattenedDocument(ctx context.Context, args *GetFlattenedDocumentArgs) (reply *GetFlattenedDocumentReply, err error) {
 	reply = new(GetFlattenedDocumentReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getFlattenedDocument", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getFlattenedDocument", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getFlattenedDocument", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getFlattenedDocument", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetFlattenedDocument", Err: err}
@@ -211,9 +219,9 @@ func (d *domainClient) GetFlattenedDocument(ctx context.Context, args *GetFlatte
 func (d *domainClient) GetNodeForLocation(ctx context.Context, args *GetNodeForLocationArgs) (reply *GetNodeForLocationReply, err error) {
 	reply = new(GetNodeForLocationReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getNodeForLocation", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getNodeForLocation", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getNodeForLocation", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getNodeForLocation", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetNodeForLocation", Err: err}
@@ -225,9 +233,9 @@ func (d *domainClient) GetNodeForLocation(ctx context.Context, args *GetNodeForL
 func (d *domainClient) GetOuterHTML(ctx context.Context, args *GetOuterHTMLArgs) (reply *GetOuterHTMLReply, err error) {
 	reply = new(GetOuterHTMLReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getOuterHTML", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getOuterHTML", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getOuterHTML", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getOuterHTML", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetOuterHTML", Err: err}
@@ -240,9 +248,9 @@ func (d *domainClient) GetOuterHTML(ctx context.Context, args *GetOuterHTMLArgs)
 func (d *domainClient) GetRelayoutBoundary(ctx context.Context, args *GetRelayoutBoundaryArgs) (reply *GetRelayoutBoundaryReply, err error) {
 	reply = new(GetRelayoutBoundaryReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getRelayoutBoundary", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getRelayoutBoundary", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getRelayoutBoundary", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getRelayoutBoundary", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetRelayoutBoundary", Err: err}
@@ -255,9 +263,9 @@ func (d *domainClient) GetRelayoutBoundary(ctx context.Context, args *GetRelayou
 func (d *domainClient) GetSearchResults(ctx context.Context, args *GetSearchResultsArgs) (reply *GetSearchResultsReply, err error) {
 	reply = new(GetSearchResultsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getSearchResults", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getSearchResults", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getSearchResults", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getSearchResults", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetSearchResults", Err: err}
@@ -267,7 +275,7 @@ func (d *domainClient) GetSearchResults(ctx context.Context, args *GetSearchResu
 
 // MarkUndoableState invokes the DOM method. Marks last undoable state.
 func (d *domainClient) MarkUndoableState(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOM.markUndoableState", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOM.markUndoableState", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "MarkUndoableState", Err: err}
 	}
@@ -279,9 +287,9 @@ func (d *domainClient) MarkUndoableState(ctx context.Context) (err error) {
 func (d *domainClient) MoveTo(ctx context.Context, args *MoveToArgs) (reply *MoveToReply, err error) {
 	reply = new(MoveToReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.moveTo", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.moveTo", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.moveTo", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.moveTo", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "MoveTo", Err: err}
@@ -295,9 +303,9 @@ func (d *domainClient) MoveTo(ctx context.Context, args *MoveToArgs) (reply *Mov
 func (d *domainClient) PerformSearch(ctx context.Context, args *PerformSearchArgs) (reply *PerformSearchReply, err error) {
 	reply = new(PerformSearchReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.performSearch", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.performSearch", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.performSearch", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.performSearch", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "PerformSearch", Err: err}
@@ -310,9 +318,9 @@ func (d *domainClient) PerformSearch(ctx context.Context, args *PerformSearchArg
 func (d *domainClient) PushNodeByPathToFrontend(ctx context.Context, args *PushNodeByPathToFrontendArgs) (reply *PushNodeByPathToFrontendReply, err error) {
 	reply = new(PushNodeByPathToFrontendReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.pushNodeByPathToFrontend", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.pushNodeByPathToFrontend", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.pushNodeByPathToFrontend", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.pushNodeByPathToFrontend", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "PushNodeByPathToFrontend", Err: err}
@@ -325,9 +333,9 @@ func (d *domainClient) PushNodeByPathToFrontend(ctx context.Context, args *PushN
 func (d *domainClient) PushNodesByBackendIDsToFrontend(ctx context.Context, args *PushNodesByBackendIDsToFrontendArgs) (reply *PushNodesByBackendIDsToFrontendReply, err error) {
 	reply = new(PushNodesByBackendIDsToFrontendReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.pushNodesByBackendIdsToFrontend", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.pushNodesByBackendIdsToFrontend", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.pushNodesByBackendIdsToFrontend", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.pushNodesByBackendIdsToFrontend", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "PushNodesByBackendIDsToFrontend", Err: err}
@@ -340,9 +348,9 @@ func (d *domainClient) PushNodesByBackendIDsToFrontend(ctx context.Context, args
 func (d *domainClient) QuerySelector(ctx context.Context, args *QuerySelectorArgs) (reply *QuerySelectorReply, err error) {
 	reply = new(QuerySelectorReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.querySelector", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.querySelector", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.querySelector", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.querySelector", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "QuerySelector", Err: err}
@@ -355,9 +363,9 @@ func (d *domainClient) QuerySelector(ctx context.Context, args *QuerySelectorArg
 func (d *domainClient) QuerySelectorAll(ctx context.Context, args *QuerySelectorAllArgs) (reply *QuerySelectorAllReply, err error) {
 	reply = new(QuerySelectorAllReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.querySelectorAll", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.querySelectorAll", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.querySelectorAll", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.querySelectorAll", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "QuerySelectorAll", Err: err}
@@ -367,7 +375,7 @@ func (d *domainClient) QuerySelectorAll(ctx context.Context, args *QuerySelector
 
 // Redo invokes the DOM method. Re-does the last undone action.
 func (d *domainClient) Redo(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOM.redo", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOM.redo", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "Redo", Err: err}
 	}
@@ -378,9 +386,9 @@ func (d *domainClient) Redo(ctx context.Context) (err error) {
 // from an element with given id.
 func (d *domainClient) RemoveAttribute(ctx context.Context, args *RemoveAttributeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.removeAttribute", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.removeAttribute", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.removeAttribute", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.removeAttribute", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "RemoveAttribute", Err: err}
@@ -391,9 +399,9 @@ func (d *domainClient) RemoveAttribute(ctx context.Context, args *RemoveAttribut
 // RemoveNode invokes the DOM method. Removes node with given id.
 func (d *domainClient) RemoveNode(ctx context.Context, args *RemoveNodeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.removeNode", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.removeNode", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.removeNode", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.removeNode", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "RemoveNode", Err: err}
@@ -407,9 +415,9 @@ func (d *domainClient) RemoveNode(ctx context.Context, args *RemoveNodeArgs) (er
 // down to the specified depth.
 func (d *domainClient) RequestChildNodes(ctx context.Context, args *RequestChildNodesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.requestChildNodes", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.requestChildNodes", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.requestChildNodes", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.requestChildNodes", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "RequestChildNodes", Err: err}
@@ -424,9 +432,9 @@ func (d *domainClient) RequestChildNodes(ctx context.Context, args *RequestChild
 func (d *domainClient) RequestNode(ctx context.Context, args *RequestNodeArgs) (reply *RequestNodeReply, err error) {
 	reply = new(RequestNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.requestNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.requestNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.requestNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.requestNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "RequestNode", Err: err}
@@ -439,9 +447,9 @@ func (d *domainClient) RequestNode(ctx context.Context, args *RequestNodeArgs) (
 func (d *domainClient) ResolveNode(ctx context.Context, args *ResolveNodeArgs) (reply *ResolveNodeReply, err error) {
 	reply = new(ResolveNodeReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.resolveNode", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.resolveNode", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.resolveNode", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.resolveNode", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "ResolveNode", Err: err}
@@ -453,9 +461,9 @@ func (d *domainClient) ResolveNode(ctx context.Context, args *ResolveNodeArgs) (
 // with given id.
 func (d *domainClient) SetAttributeValue(ctx context.Context, args *SetAttributeValueArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setAttributeValue", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setAttributeValue", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setAttributeValue", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setAttributeValue", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetAttributeValue", Err: err}
@@ -468,9 +476,9 @@ func (d *domainClient) SetAttributeValue(ctx context.Context, args *SetAttribute
 // value and types in several attribute name/value pairs.
 func (d *domainClient) SetAttributesAsText(ctx context.Context, args *SetAttributesAsTextArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setAttributesAsText", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setAttributesAsText", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setAttributesAsText", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setAttributesAsText", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetAttributesAsText", Err: err}
@@ -482,9 +490,9 @@ func (d *domainClient) SetAttributesAsText(ctx context.Context, args *SetAttribu
 // input element.
 func (d *domainClient) SetFileInputFiles(ctx context.Context, args *SetFileInputFilesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setFileInputFiles", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setFileInputFiles", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setFileInputFiles", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setFileInputFiles", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetFileInputFiles", Err: err}
@@ -497,9 +505,9 @@ func (d *domainClient) SetFileInputFiles(ctx context.Context, args *SetFileInput
 func (d *domainClient) GetFileInfo(ctx context.Context, args *GetFileInfoArgs) (reply *GetFileInfoReply, err error) {
 	reply = new(GetFileInfoReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getFileInfo", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getFileInfo", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getFileInfo", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getFileInfo", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetFileInfo", Err: err}
@@ -512,9 +520,9 @@ func (d *domainClient) GetFileInfo(ctx context.Context, args *GetFileInfoArgs) (
 // functions).
 func (d *domainClient) SetInspectedNode(ctx context.Context, args *SetInspectedNodeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setInspectedNode", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setInspectedNode", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setInspectedNode", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setInspectedNode", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetInspectedNode", Err: err}
@@ -527,9 +535,9 @@ func (d *domainClient) SetInspectedNode(ctx context.Context, args *SetInspectedN
 func (d *domainClient) SetNodeName(ctx context.Context, args *SetNodeNameArgs) (reply *SetNodeNameReply, err error) {
 	reply = new(SetNodeNameReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setNodeName", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setNodeName", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setNodeName", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setNodeName", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetNodeName", Err: err}
@@ -541,9 +549,9 @@ func (d *domainClient) SetNodeName(ctx context.Context, args *SetNodeNameArgs) (
 // id.
 func (d *domainClient) SetNodeValue(ctx context.Context, args *SetNodeValueArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setNodeValue", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setNodeValue", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setNodeValue", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setNodeValue", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetNodeValue", Err: err}
@@ -555,9 +563,9 @@ func (d *domainClient) SetNodeValue(ctx context.Context, args *SetNodeValueArgs)
 // node id.
 func (d *domainClient) SetOuterHTML(ctx context.Context, args *SetOuterHTMLArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.setOuterHTML", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setOuterHTML", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.setOuterHTML", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.setOuterHTML", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "SetOuterHTML", Err: err}
@@ -567,7 +575,7 @@ func (d *domainClient) SetOuterHTML(ctx context.Context, args *SetOuterHTMLArgs)
 
 // Undo invokes the DOM method. Undoes the last performed action.
 func (d *domainClient) Undo(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOM.undo", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOM.undo", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "Undo", Err: err}
 	}
@@ -579,9 +587,9 @@ func (d *domainClient) Undo(ctx context.Context) (err error) {
 func (d *domainClient) GetFrameOwner(ctx context.Context, args *GetFrameOwnerArgs) (reply *GetFrameOwnerReply, err error) {
 	reply = new(GetFrameOwnerReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOM.getFrameOwner", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getFrameOwner", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOM.getFrameOwner", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOM.getFrameOwner", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOM", Op: "GetFrameOwner", Err: err}
@@ -590,7 +598,7 @@ func (d *domainClient) GetFrameOwner(ctx context.Context, args *GetFrameOwnerArg
 }
 
 func (d *domainClient) AttributeModified(ctx context.Context) (AttributeModifiedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.attributeModified", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.attributeModified", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +619,7 @@ func (c *attributeModifiedClient) Recv() (*AttributeModifiedReply, error) {
 }
 
 func (d *domainClient) AttributeRemoved(ctx context.Context) (AttributeRemovedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.attributeRemoved", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.attributeRemoved", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +640,7 @@ func (c *attributeRemovedClient) Recv() (*AttributeRemovedReply, error) {
 }
 
 func (d *domainClient) CharacterDataModified(ctx context.Context) (CharacterDataModifiedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.characterDataModified", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.characterDataModified", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -653,7 +661,7 @@ func (c *characterDataModifiedClient) Recv() (*CharacterDataModifiedReply, error
 }
 
 func (d *domainClient) ChildNodeCountUpdated(ctx context.Context) (ChildNodeCountUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.childNodeCountUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.childNodeCountUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -674,7 +682,7 @@ func (c *childNodeCountUpdatedClient) Recv() (*ChildNodeCountUpdatedReply, error
 }
 
 func (d *domainClient) ChildNodeInserted(ctx context.Context) (ChildNodeInsertedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.childNodeInserted", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.childNodeInserted", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -695,7 +703,7 @@ func (c *childNodeInsertedClient) Recv() (*ChildNodeInsertedReply, error) {
 }
 
 func (d *domainClient) ChildNodeRemoved(ctx context.Context) (ChildNodeRemovedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.childNodeRemoved", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.childNodeRemoved", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +724,7 @@ func (c *childNodeRemovedClient) Recv() (*ChildNodeRemovedReply, error) {
 }
 
 func (d *domainClient) DistributedNodesUpdated(ctx context.Context) (DistributedNodesUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.distributedNodesUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.distributedNodesUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -737,7 +745,7 @@ func (c *distributedNodesUpdatedClient) Recv() (*DistributedNodesUpdatedReply, e
 }
 
 func (d *domainClient) DocumentUpdated(ctx context.Context) (DocumentUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.documentUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.documentUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -758,7 +766,7 @@ func (c *documentUpdatedClient) Recv() (*DocumentUpdatedReply, error) {
 }
 
 func (d *domainClient) InlineStyleInvalidated(ctx context.Context) (InlineStyleInvalidatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.inlineStyleInvalidated", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.inlineStyleInvalidated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -779,7 +787,7 @@ func (c *inlineStyleInvalidatedClient) Recv() (*InlineStyleInvalidatedReply, err
 }
 
 func (d *domainClient) PseudoElementAdded(ctx context.Context) (PseudoElementAddedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.pseudoElementAdded", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.pseudoElementAdded", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -800,7 +808,7 @@ func (c *pseudoElementAddedClient) Recv() (*PseudoElementAddedReply, error) {
 }
 
 func (d *domainClient) PseudoElementRemoved(ctx context.Context) (PseudoElementRemovedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.pseudoElementRemoved", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.pseudoElementRemoved", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -821,7 +829,7 @@ func (c *pseudoElementRemovedClient) Recv() (*PseudoElementRemovedReply, error) 
 }
 
 func (d *domainClient) SetChildNodes(ctx context.Context) (SetChildNodesClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.setChildNodes", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.setChildNodes", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +850,7 @@ func (c *setChildNodesClient) Recv() (*SetChildNodesReply, error) {
 }
 
 func (d *domainClient) ShadowRootPopped(ctx context.Context) (ShadowRootPoppedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.shadowRootPopped", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.shadowRootPopped", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -863,7 +871,7 @@ func (c *shadowRootPoppedClient) Recv() (*ShadowRootPoppedReply, error) {
 }
 
 func (d *domainClient) ShadowRootPushed(ctx context.Context) (ShadowRootPushedClient, error) {
-	s, err := rpcc.NewStream(ctx, "DOM.shadowRootPushed", d.conn)
+	s, err := rpcc.NewStream(ctx, "DOM.shadowRootPushed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/domdebugger/domain.go
+++ b/protocol/domdebugger/domain.go
@@ -17,11 +17,19 @@ import (
 // setting breakpoints on particular DOM operations and events. JavaScript
 // execution will stop on these operations as if there was a regular breakpoint
 // set.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the DOMDebugger domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the DOMDebugger domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // GetEventListeners invokes the DOMDebugger method. Returns event listeners
@@ -29,9 +37,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) GetEventListeners(ctx context.Context, args *GetEventListenersArgs) (reply *GetEventListenersReply, err error) {
 	reply = new(GetEventListenersReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.getEventListeners", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.getEventListeners", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.getEventListeners", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.getEventListeners", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "GetEventListeners", Err: err}
@@ -43,9 +51,9 @@ func (d *domainClient) GetEventListeners(ctx context.Context, args *GetEventList
 // that was set using `setDOMBreakpoint`.
 func (d *domainClient) RemoveDOMBreakpoint(ctx context.Context, args *RemoveDOMBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeDOMBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeDOMBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeDOMBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeDOMBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "RemoveDOMBreakpoint", Err: err}
@@ -57,9 +65,9 @@ func (d *domainClient) RemoveDOMBreakpoint(ctx context.Context, args *RemoveDOMB
 // breakpoint on particular DOM event.
 func (d *domainClient) RemoveEventListenerBreakpoint(ctx context.Context, args *RemoveEventListenerBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeEventListenerBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeEventListenerBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeEventListenerBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeEventListenerBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "RemoveEventListenerBreakpoint", Err: err}
@@ -71,9 +79,9 @@ func (d *domainClient) RemoveEventListenerBreakpoint(ctx context.Context, args *
 // breakpoint on particular native event.
 func (d *domainClient) RemoveInstrumentationBreakpoint(ctx context.Context, args *RemoveInstrumentationBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeInstrumentationBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeInstrumentationBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeInstrumentationBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeInstrumentationBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "RemoveInstrumentationBreakpoint", Err: err}
@@ -85,9 +93,9 @@ func (d *domainClient) RemoveInstrumentationBreakpoint(ctx context.Context, args
 // XMLHttpRequest.
 func (d *domainClient) RemoveXHRBreakpoint(ctx context.Context, args *RemoveXHRBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeXHRBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeXHRBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.removeXHRBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.removeXHRBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "RemoveXHRBreakpoint", Err: err}
@@ -99,9 +107,9 @@ func (d *domainClient) RemoveXHRBreakpoint(ctx context.Context, args *RemoveXHRB
 // particular operation with DOM.
 func (d *domainClient) SetDOMBreakpoint(ctx context.Context, args *SetDOMBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setDOMBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setDOMBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setDOMBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setDOMBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "SetDOMBreakpoint", Err: err}
@@ -113,9 +121,9 @@ func (d *domainClient) SetDOMBreakpoint(ctx context.Context, args *SetDOMBreakpo
 // on particular DOM event.
 func (d *domainClient) SetEventListenerBreakpoint(ctx context.Context, args *SetEventListenerBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setEventListenerBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setEventListenerBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setEventListenerBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setEventListenerBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "SetEventListenerBreakpoint", Err: err}
@@ -127,9 +135,9 @@ func (d *domainClient) SetEventListenerBreakpoint(ctx context.Context, args *Set
 // breakpoint on particular native event.
 func (d *domainClient) SetInstrumentationBreakpoint(ctx context.Context, args *SetInstrumentationBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setInstrumentationBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setInstrumentationBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setInstrumentationBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setInstrumentationBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "SetInstrumentationBreakpoint", Err: err}
@@ -141,9 +149,9 @@ func (d *domainClient) SetInstrumentationBreakpoint(ctx context.Context, args *S
 // XMLHttpRequest.
 func (d *domainClient) SetXHRBreakpoint(ctx context.Context, args *SetXHRBreakpointArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setXHRBreakpoint", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setXHRBreakpoint", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMDebugger.setXHRBreakpoint", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMDebugger.setXHRBreakpoint", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMDebugger", Op: "SetXHRBreakpoint", Err: err}

--- a/protocol/domsnapshot/domain.go
+++ b/protocol/domsnapshot/domain.go
@@ -15,17 +15,25 @@ import (
 // domainClient is a client for the DOMSnapshot domain. This domain
 // facilitates obtaining document snapshots with DOM, layout, and style
 // information.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the DOMSnapshot domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the DOMSnapshot domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the DOMSnapshot method. Disables DOM snapshot agent for the
 // given page.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOMSnapshot.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOMSnapshot.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMSnapshot", Op: "Disable", Err: err}
 	}
@@ -35,7 +43,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Enable invokes the DOMSnapshot method. Enables DOM snapshot agent for the
 // given page.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "DOMSnapshot.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "DOMSnapshot.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMSnapshot", Op: "Enable", Err: err}
 	}
@@ -50,9 +58,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) GetSnapshot(ctx context.Context, args *GetSnapshotArgs) (reply *GetSnapshotReply, err error) {
 	reply = new(GetSnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMSnapshot.getSnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMSnapshot.getSnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMSnapshot.getSnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMSnapshot.getSnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMSnapshot", Op: "GetSnapshot", Err: err}
@@ -68,9 +76,9 @@ func (d *domainClient) GetSnapshot(ctx context.Context, args *GetSnapshotArgs) (
 func (d *domainClient) CaptureSnapshot(ctx context.Context, args *CaptureSnapshotArgs) (reply *CaptureSnapshotReply, err error) {
 	reply = new(CaptureSnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "DOMSnapshot.captureSnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMSnapshot.captureSnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "DOMSnapshot.captureSnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "DOMSnapshot.captureSnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "DOMSnapshot", Op: "CaptureSnapshot", Err: err}

--- a/protocol/emulation/domain.go
+++ b/protocol/emulation/domain.go
@@ -13,18 +13,26 @@ import (
 
 // domainClient is a client for the Emulation domain. This domain emulates
 // different environments for the page.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Emulation domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Emulation domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // CanEmulate invokes the Emulation method. Tells whether emulation is
 // supported.
 func (d *domainClient) CanEmulate(ctx context.Context) (reply *CanEmulateReply, err error) {
 	reply = new(CanEmulateReply)
-	err = rpcc.Invoke(ctx, "Emulation.canEmulate", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Emulation.canEmulate", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "CanEmulate", Err: err}
 	}
@@ -34,7 +42,7 @@ func (d *domainClient) CanEmulate(ctx context.Context) (reply *CanEmulateReply, 
 // ClearDeviceMetricsOverride invokes the Emulation method. Clears the
 // overridden device metrics.
 func (d *domainClient) ClearDeviceMetricsOverride(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Emulation.clearDeviceMetricsOverride", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Emulation.clearDeviceMetricsOverride", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "ClearDeviceMetricsOverride", Err: err}
 	}
@@ -44,7 +52,7 @@ func (d *domainClient) ClearDeviceMetricsOverride(ctx context.Context) (err erro
 // ClearGeolocationOverride invokes the Emulation method. Clears the
 // overridden Geolocation Position and Error.
 func (d *domainClient) ClearGeolocationOverride(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Emulation.clearGeolocationOverride", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Emulation.clearGeolocationOverride", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "ClearGeolocationOverride", Err: err}
 	}
@@ -54,7 +62,7 @@ func (d *domainClient) ClearGeolocationOverride(ctx context.Context) (err error)
 // ResetPageScaleFactor invokes the Emulation method. Requests that page scale
 // factor is reset to initial values.
 func (d *domainClient) ResetPageScaleFactor(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Emulation.resetPageScaleFactor", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Emulation.resetPageScaleFactor", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "ResetPageScaleFactor", Err: err}
 	}
@@ -65,9 +73,9 @@ func (d *domainClient) ResetPageScaleFactor(ctx context.Context) (err error) {
 // simulating a focused and active page.
 func (d *domainClient) SetFocusEmulationEnabled(ctx context.Context, args *SetFocusEmulationEnabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setFocusEmulationEnabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setFocusEmulationEnabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setFocusEmulationEnabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setFocusEmulationEnabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetFocusEmulationEnabled", Err: err}
@@ -79,9 +87,9 @@ func (d *domainClient) SetFocusEmulationEnabled(ctx context.Context, args *SetFo
 // to emulate slow CPUs.
 func (d *domainClient) SetCPUThrottlingRate(ctx context.Context, args *SetCPUThrottlingRateArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setCPUThrottlingRate", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setCPUThrottlingRate", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setCPUThrottlingRate", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setCPUThrottlingRate", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetCPUThrottlingRate", Err: err}
@@ -94,9 +102,9 @@ func (d *domainClient) SetCPUThrottlingRate(ctx context.Context, args *SetCPUThr
 // override is used if the content does not specify one.
 func (d *domainClient) SetDefaultBackgroundColorOverride(ctx context.Context, args *SetDefaultBackgroundColorOverrideArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setDefaultBackgroundColorOverride", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setDefaultBackgroundColorOverride", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setDefaultBackgroundColorOverride", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setDefaultBackgroundColorOverride", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetDefaultBackgroundColorOverride", Err: err}
@@ -110,9 +118,9 @@ func (d *domainClient) SetDefaultBackgroundColorOverride(ctx context.Context, ar
 // "device-width"/"device-height"-related CSS media query results).
 func (d *domainClient) SetDeviceMetricsOverride(ctx context.Context, args *SetDeviceMetricsOverrideArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setDeviceMetricsOverride", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setDeviceMetricsOverride", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setDeviceMetricsOverride", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setDeviceMetricsOverride", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetDeviceMetricsOverride", Err: err}
@@ -123,9 +131,9 @@ func (d *domainClient) SetDeviceMetricsOverride(ctx context.Context, args *SetDe
 // SetScrollbarsHidden invokes the Emulation method.
 func (d *domainClient) SetScrollbarsHidden(ctx context.Context, args *SetScrollbarsHiddenArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setScrollbarsHidden", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setScrollbarsHidden", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setScrollbarsHidden", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setScrollbarsHidden", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetScrollbarsHidden", Err: err}
@@ -136,9 +144,9 @@ func (d *domainClient) SetScrollbarsHidden(ctx context.Context, args *SetScrollb
 // SetDocumentCookieDisabled invokes the Emulation method.
 func (d *domainClient) SetDocumentCookieDisabled(ctx context.Context, args *SetDocumentCookieDisabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setDocumentCookieDisabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setDocumentCookieDisabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setDocumentCookieDisabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setDocumentCookieDisabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetDocumentCookieDisabled", Err: err}
@@ -149,9 +157,9 @@ func (d *domainClient) SetDocumentCookieDisabled(ctx context.Context, args *SetD
 // SetEmitTouchEventsForMouse invokes the Emulation method.
 func (d *domainClient) SetEmitTouchEventsForMouse(ctx context.Context, args *SetEmitTouchEventsForMouseArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setEmitTouchEventsForMouse", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setEmitTouchEventsForMouse", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setEmitTouchEventsForMouse", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setEmitTouchEventsForMouse", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetEmitTouchEventsForMouse", Err: err}
@@ -163,9 +171,9 @@ func (d *domainClient) SetEmitTouchEventsForMouse(ctx context.Context, args *Set
 // CSS media queries.
 func (d *domainClient) SetEmulatedMedia(ctx context.Context, args *SetEmulatedMediaArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setEmulatedMedia", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setEmulatedMedia", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setEmulatedMedia", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setEmulatedMedia", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetEmulatedMedia", Err: err}
@@ -178,9 +186,9 @@ func (d *domainClient) SetEmulatedMedia(ctx context.Context, args *SetEmulatedMe
 // position unavailable.
 func (d *domainClient) SetGeolocationOverride(ctx context.Context, args *SetGeolocationOverrideArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setGeolocationOverride", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setGeolocationOverride", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setGeolocationOverride", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setGeolocationOverride", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetGeolocationOverride", Err: err}
@@ -192,9 +200,9 @@ func (d *domainClient) SetGeolocationOverride(ctx context.Context, args *SetGeol
 // returned by the javascript navigator object.
 func (d *domainClient) SetNavigatorOverrides(ctx context.Context, args *SetNavigatorOverridesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setNavigatorOverrides", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setNavigatorOverrides", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setNavigatorOverrides", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setNavigatorOverrides", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetNavigatorOverrides", Err: err}
@@ -206,9 +214,9 @@ func (d *domainClient) SetNavigatorOverrides(ctx context.Context, args *SetNavig
 // scale factor.
 func (d *domainClient) SetPageScaleFactor(ctx context.Context, args *SetPageScaleFactorArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setPageScaleFactor", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setPageScaleFactor", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setPageScaleFactor", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setPageScaleFactor", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetPageScaleFactor", Err: err}
@@ -220,9 +228,9 @@ func (d *domainClient) SetPageScaleFactor(ctx context.Context, args *SetPageScal
 // execution in the page.
 func (d *domainClient) SetScriptExecutionDisabled(ctx context.Context, args *SetScriptExecutionDisabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setScriptExecutionDisabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setScriptExecutionDisabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setScriptExecutionDisabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setScriptExecutionDisabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetScriptExecutionDisabled", Err: err}
@@ -234,9 +242,9 @@ func (d *domainClient) SetScriptExecutionDisabled(ctx context.Context, args *Set
 // platforms which do not support them.
 func (d *domainClient) SetTouchEmulationEnabled(ctx context.Context, args *SetTouchEmulationEnabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setTouchEmulationEnabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setTouchEmulationEnabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setTouchEmulationEnabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setTouchEmulationEnabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetTouchEmulationEnabled", Err: err}
@@ -251,9 +259,9 @@ func (d *domainClient) SetTouchEmulationEnabled(ctx context.Context, args *SetTo
 func (d *domainClient) SetVirtualTimePolicy(ctx context.Context, args *SetVirtualTimePolicyArgs) (reply *SetVirtualTimePolicyReply, err error) {
 	reply = new(SetVirtualTimePolicyReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setVirtualTimePolicy", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setVirtualTimePolicy", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setVirtualTimePolicy", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setVirtualTimePolicy", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetVirtualTimePolicy", Err: err}
@@ -265,9 +273,9 @@ func (d *domainClient) SetVirtualTimePolicy(ctx context.Context, args *SetVirtua
 // system timezone with the specified one.
 func (d *domainClient) SetTimezoneOverride(ctx context.Context, args *SetTimezoneOverrideArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setTimezoneOverride", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setTimezoneOverride", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setTimezoneOverride", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setTimezoneOverride", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetTimezoneOverride", Err: err}
@@ -281,9 +289,9 @@ func (d *domainClient) SetTimezoneOverride(ctx context.Context, args *SetTimezon
 // supported on Android.
 func (d *domainClient) SetVisibleSize(ctx context.Context, args *SetVisibleSizeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setVisibleSize", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setVisibleSize", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setVisibleSize", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setVisibleSize", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetVisibleSize", Err: err}
@@ -295,9 +303,9 @@ func (d *domainClient) SetVisibleSize(ctx context.Context, args *SetVisibleSizeA
 // agent with the given string.
 func (d *domainClient) SetUserAgentOverride(ctx context.Context, args *SetUserAgentOverrideArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Emulation.setUserAgentOverride", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setUserAgentOverride", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Emulation.setUserAgentOverride", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Emulation.setUserAgentOverride", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Emulation", Op: "SetUserAgentOverride", Err: err}
@@ -306,7 +314,7 @@ func (d *domainClient) SetUserAgentOverride(ctx context.Context, args *SetUserAg
 }
 
 func (d *domainClient) VirtualTimeBudgetExpired(ctx context.Context) (VirtualTimeBudgetExpiredClient, error) {
-	s, err := rpcc.NewStream(ctx, "Emulation.virtualTimeBudgetExpired", d.conn)
+	s, err := rpcc.NewStream(ctx, "Emulation.virtualTimeBudgetExpired", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/fetch/domain.go
+++ b/protocol/fetch/domain.go
@@ -13,16 +13,24 @@ import (
 
 // domainClient is a client for the Fetch domain. A domain for letting clients
 // substitute browser's network layer with client code.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Fetch domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Fetch domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Fetch method. Disables the fetch domain.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Fetch.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Fetch.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "Disable", Err: err}
 	}
@@ -34,9 +42,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // or continueRequest/continueWithAuth.
 func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.enable", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.enable", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.enable", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.enable", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "Enable", Err: err}
@@ -48,9 +56,9 @@ func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (err error)
 // specified reason.
 func (d *domainClient) FailRequest(ctx context.Context, args *FailRequestArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.failRequest", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.failRequest", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.failRequest", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.failRequest", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "FailRequest", Err: err}
@@ -61,9 +69,9 @@ func (d *domainClient) FailRequest(ctx context.Context, args *FailRequestArgs) (
 // FulfillRequest invokes the Fetch method. Provides response to the request.
 func (d *domainClient) FulfillRequest(ctx context.Context, args *FulfillRequestArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.fulfillRequest", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.fulfillRequest", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.fulfillRequest", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.fulfillRequest", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "FulfillRequest", Err: err}
@@ -75,9 +83,9 @@ func (d *domainClient) FulfillRequest(ctx context.Context, args *FulfillRequestA
 // modifying some of its parameters.
 func (d *domainClient) ContinueRequest(ctx context.Context, args *ContinueRequestArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.continueRequest", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.continueRequest", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.continueRequest", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.continueRequest", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "ContinueRequest", Err: err}
@@ -89,9 +97,9 @@ func (d *domainClient) ContinueRequest(ctx context.Context, args *ContinueReques
 // authChallengeResponse following authRequired event.
 func (d *domainClient) ContinueWithAuth(ctx context.Context, args *ContinueWithAuthArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.continueWithAuth", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.continueWithAuth", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.continueWithAuth", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.continueWithAuth", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "ContinueWithAuth", Err: err}
@@ -108,9 +116,9 @@ func (d *domainClient) ContinueWithAuth(ctx context.Context, args *ContinueWithA
 func (d *domainClient) GetResponseBody(ctx context.Context, args *GetResponseBodyArgs) (reply *GetResponseBodyReply, err error) {
 	reply = new(GetResponseBodyReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.getResponseBody", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.getResponseBody", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.getResponseBody", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.getResponseBody", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "GetResponseBody", Err: err}
@@ -129,9 +137,9 @@ func (d *domainClient) GetResponseBody(ctx context.Context, args *GetResponseBod
 func (d *domainClient) TakeResponseBodyAsStream(ctx context.Context, args *TakeResponseBodyAsStreamArgs) (reply *TakeResponseBodyAsStreamReply, err error) {
 	reply = new(TakeResponseBodyAsStreamReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Fetch.takeResponseBodyAsStream", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.takeResponseBodyAsStream", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Fetch.takeResponseBodyAsStream", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Fetch.takeResponseBodyAsStream", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Fetch", Op: "TakeResponseBodyAsStream", Err: err}
@@ -140,7 +148,7 @@ func (d *domainClient) TakeResponseBodyAsStream(ctx context.Context, args *TakeR
 }
 
 func (d *domainClient) RequestPaused(ctx context.Context) (RequestPausedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Fetch.requestPaused", d.conn)
+	s, err := rpcc.NewStream(ctx, "Fetch.requestPaused", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +169,7 @@ func (c *requestPausedClient) Recv() (*RequestPausedReply, error) {
 }
 
 func (d *domainClient) AuthRequired(ctx context.Context) (AuthRequiredClient, error) {
-	s, err := rpcc.NewStream(ctx, "Fetch.authRequired", d.conn)
+	s, err := rpcc.NewStream(ctx, "Fetch.authRequired", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/headlessexperimental/domain.go
+++ b/protocol/headlessexperimental/domain.go
@@ -13,11 +13,19 @@ import (
 
 // domainClient is a client for the HeadlessExperimental domain. This domain
 // provides experimental commands only supported in headless mode.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the HeadlessExperimental domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the HeadlessExperimental domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // BeginFrame invokes the HeadlessExperimental method. Sends a BeginFrame to
@@ -29,9 +37,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) BeginFrame(ctx context.Context, args *BeginFrameArgs) (reply *BeginFrameReply, err error) {
 	reply = new(BeginFrameReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeadlessExperimental.beginFrame", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeadlessExperimental.beginFrame", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeadlessExperimental.beginFrame", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeadlessExperimental.beginFrame", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeadlessExperimental", Op: "BeginFrame", Err: err}
@@ -42,7 +50,7 @@ func (d *domainClient) BeginFrame(ctx context.Context, args *BeginFrameArgs) (re
 // Disable invokes the HeadlessExperimental method. Disables headless events
 // for the target.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "HeadlessExperimental.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeadlessExperimental.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeadlessExperimental", Op: "Disable", Err: err}
 	}
@@ -52,7 +60,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Enable invokes the HeadlessExperimental method. Enables headless events for
 // the target.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "HeadlessExperimental.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeadlessExperimental.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeadlessExperimental", Op: "Enable", Err: err}
 	}
@@ -60,7 +68,7 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 }
 
 func (d *domainClient) NeedsBeginFramesChanged(ctx context.Context) (NeedsBeginFramesChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "HeadlessExperimental.needsBeginFramesChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "HeadlessExperimental.needsBeginFramesChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/heapprofiler/domain.go
+++ b/protocol/heapprofiler/domain.go
@@ -11,11 +11,19 @@ import (
 )
 
 // domainClient is a client for the HeapProfiler domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the HeapProfiler domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the HeapProfiler domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // AddInspectedHeapObject invokes the HeapProfiler method. Enables console to
@@ -23,9 +31,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 // details $x functions).
 func (d *domainClient) AddInspectedHeapObject(ctx context.Context, args *AddInspectedHeapObjectArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.addInspectedHeapObject", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.addInspectedHeapObject", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.addInspectedHeapObject", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.addInspectedHeapObject", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "AddInspectedHeapObject", Err: err}
@@ -35,7 +43,7 @@ func (d *domainClient) AddInspectedHeapObject(ctx context.Context, args *AddInsp
 
 // CollectGarbage invokes the HeapProfiler method.
 func (d *domainClient) CollectGarbage(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "HeapProfiler.collectGarbage", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeapProfiler.collectGarbage", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "CollectGarbage", Err: err}
 	}
@@ -44,7 +52,7 @@ func (d *domainClient) CollectGarbage(ctx context.Context) (err error) {
 
 // Disable invokes the HeapProfiler method.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "HeapProfiler.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeapProfiler.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "Disable", Err: err}
 	}
@@ -53,7 +61,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 
 // Enable invokes the HeapProfiler method.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "HeapProfiler.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeapProfiler.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "Enable", Err: err}
 	}
@@ -64,9 +72,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) GetHeapObjectID(ctx context.Context, args *GetHeapObjectIDArgs) (reply *GetHeapObjectIDReply, err error) {
 	reply = new(GetHeapObjectIDReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.getHeapObjectId", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.getHeapObjectId", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.getHeapObjectId", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.getHeapObjectId", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "GetHeapObjectID", Err: err}
@@ -78,9 +86,9 @@ func (d *domainClient) GetHeapObjectID(ctx context.Context, args *GetHeapObjectI
 func (d *domainClient) GetObjectByHeapObjectID(ctx context.Context, args *GetObjectByHeapObjectIDArgs) (reply *GetObjectByHeapObjectIDReply, err error) {
 	reply = new(GetObjectByHeapObjectIDReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.getObjectByHeapObjectId", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.getObjectByHeapObjectId", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.getObjectByHeapObjectId", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.getObjectByHeapObjectId", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "GetObjectByHeapObjectID", Err: err}
@@ -91,7 +99,7 @@ func (d *domainClient) GetObjectByHeapObjectID(ctx context.Context, args *GetObj
 // GetSamplingProfile invokes the HeapProfiler method.
 func (d *domainClient) GetSamplingProfile(ctx context.Context) (reply *GetSamplingProfileReply, err error) {
 	reply = new(GetSamplingProfileReply)
-	err = rpcc.Invoke(ctx, "HeapProfiler.getSamplingProfile", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeapProfiler.getSamplingProfile", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "GetSamplingProfile", Err: err}
 	}
@@ -101,9 +109,9 @@ func (d *domainClient) GetSamplingProfile(ctx context.Context) (reply *GetSampli
 // StartSampling invokes the HeapProfiler method.
 func (d *domainClient) StartSampling(ctx context.Context, args *StartSamplingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.startSampling", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.startSampling", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.startSampling", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.startSampling", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "StartSampling", Err: err}
@@ -114,9 +122,9 @@ func (d *domainClient) StartSampling(ctx context.Context, args *StartSamplingArg
 // StartTrackingHeapObjects invokes the HeapProfiler method.
 func (d *domainClient) StartTrackingHeapObjects(ctx context.Context, args *StartTrackingHeapObjectsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.startTrackingHeapObjects", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.startTrackingHeapObjects", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.startTrackingHeapObjects", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.startTrackingHeapObjects", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "StartTrackingHeapObjects", Err: err}
@@ -127,7 +135,7 @@ func (d *domainClient) StartTrackingHeapObjects(ctx context.Context, args *Start
 // StopSampling invokes the HeapProfiler method.
 func (d *domainClient) StopSampling(ctx context.Context) (reply *StopSamplingReply, err error) {
 	reply = new(StopSamplingReply)
-	err = rpcc.Invoke(ctx, "HeapProfiler.stopSampling", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "HeapProfiler.stopSampling", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "StopSampling", Err: err}
 	}
@@ -137,9 +145,9 @@ func (d *domainClient) StopSampling(ctx context.Context) (reply *StopSamplingRep
 // StopTrackingHeapObjects invokes the HeapProfiler method.
 func (d *domainClient) StopTrackingHeapObjects(ctx context.Context, args *StopTrackingHeapObjectsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.stopTrackingHeapObjects", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.stopTrackingHeapObjects", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.stopTrackingHeapObjects", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.stopTrackingHeapObjects", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "StopTrackingHeapObjects", Err: err}
@@ -150,9 +158,9 @@ func (d *domainClient) StopTrackingHeapObjects(ctx context.Context, args *StopTr
 // TakeHeapSnapshot invokes the HeapProfiler method.
 func (d *domainClient) TakeHeapSnapshot(ctx context.Context, args *TakeHeapSnapshotArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "HeapProfiler.takeHeapSnapshot", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.takeHeapSnapshot", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "HeapProfiler.takeHeapSnapshot", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "HeapProfiler.takeHeapSnapshot", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "HeapProfiler", Op: "TakeHeapSnapshot", Err: err}
@@ -161,7 +169,7 @@ func (d *domainClient) TakeHeapSnapshot(ctx context.Context, args *TakeHeapSnaps
 }
 
 func (d *domainClient) AddHeapSnapshotChunk(ctx context.Context) (AddHeapSnapshotChunkClient, error) {
-	s, err := rpcc.NewStream(ctx, "HeapProfiler.addHeapSnapshotChunk", d.conn)
+	s, err := rpcc.NewStream(ctx, "HeapProfiler.addHeapSnapshotChunk", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +190,7 @@ func (c *addHeapSnapshotChunkClient) Recv() (*AddHeapSnapshotChunkReply, error) 
 }
 
 func (d *domainClient) HeapStatsUpdate(ctx context.Context) (HeapStatsUpdateClient, error) {
-	s, err := rpcc.NewStream(ctx, "HeapProfiler.heapStatsUpdate", d.conn)
+	s, err := rpcc.NewStream(ctx, "HeapProfiler.heapStatsUpdate", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +211,7 @@ func (c *heapStatsUpdateClient) Recv() (*HeapStatsUpdateReply, error) {
 }
 
 func (d *domainClient) LastSeenObjectID(ctx context.Context) (LastSeenObjectIDClient, error) {
-	s, err := rpcc.NewStream(ctx, "HeapProfiler.lastSeenObjectId", d.conn)
+	s, err := rpcc.NewStream(ctx, "HeapProfiler.lastSeenObjectId", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +232,7 @@ func (c *lastSeenObjectIDClient) Recv() (*LastSeenObjectIDReply, error) {
 }
 
 func (d *domainClient) ReportHeapSnapshotProgress(ctx context.Context) (ReportHeapSnapshotProgressClient, error) {
-	s, err := rpcc.NewStream(ctx, "HeapProfiler.reportHeapSnapshotProgress", d.conn)
+	s, err := rpcc.NewStream(ctx, "HeapProfiler.reportHeapSnapshotProgress", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +253,7 @@ func (c *reportHeapSnapshotProgressClient) Recv() (*ReportHeapSnapshotProgressRe
 }
 
 func (d *domainClient) ResetProfiles(ctx context.Context) (ResetProfilesClient, error) {
-	s, err := rpcc.NewStream(ctx, "HeapProfiler.resetProfiles", d.conn)
+	s, err := rpcc.NewStream(ctx, "HeapProfiler.resetProfiles", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/indexeddb/domain.go
+++ b/protocol/indexeddb/domain.go
@@ -11,20 +11,28 @@ import (
 )
 
 // domainClient is a client for the IndexedDB domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the IndexedDB domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the IndexedDB domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // ClearObjectStore invokes the IndexedDB method. Clears all entries from an
 // object store.
 func (d *domainClient) ClearObjectStore(ctx context.Context, args *ClearObjectStoreArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.clearObjectStore", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.clearObjectStore", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.clearObjectStore", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.clearObjectStore", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "ClearObjectStore", Err: err}
@@ -35,9 +43,9 @@ func (d *domainClient) ClearObjectStore(ctx context.Context, args *ClearObjectSt
 // DeleteDatabase invokes the IndexedDB method. Deletes a database.
 func (d *domainClient) DeleteDatabase(ctx context.Context, args *DeleteDatabaseArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.deleteDatabase", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.deleteDatabase", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.deleteDatabase", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.deleteDatabase", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "DeleteDatabase", Err: err}
@@ -49,9 +57,9 @@ func (d *domainClient) DeleteDatabase(ctx context.Context, args *DeleteDatabaseA
 // entries from an object store
 func (d *domainClient) DeleteObjectStoreEntries(ctx context.Context, args *DeleteObjectStoreEntriesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.deleteObjectStoreEntries", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.deleteObjectStoreEntries", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.deleteObjectStoreEntries", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.deleteObjectStoreEntries", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "DeleteObjectStoreEntries", Err: err}
@@ -61,7 +69,7 @@ func (d *domainClient) DeleteObjectStoreEntries(ctx context.Context, args *Delet
 
 // Disable invokes the IndexedDB method. Disables events from backend.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "IndexedDB.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "IndexedDB.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "Disable", Err: err}
 	}
@@ -70,7 +78,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 
 // Enable invokes the IndexedDB method. Enables events from backend.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "IndexedDB.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "IndexedDB.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "Enable", Err: err}
 	}
@@ -82,9 +90,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) RequestData(ctx context.Context, args *RequestDataArgs) (reply *RequestDataReply, err error) {
 	reply = new(RequestDataReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.requestData", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.requestData", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.requestData", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.requestData", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "RequestData", Err: err}
@@ -96,9 +104,9 @@ func (d *domainClient) RequestData(ctx context.Context, args *RequestDataArgs) (
 func (d *domainClient) GetMetadata(ctx context.Context, args *GetMetadataArgs) (reply *GetMetadataReply, err error) {
 	reply = new(GetMetadataReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.getMetadata", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.getMetadata", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.getMetadata", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.getMetadata", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "GetMetadata", Err: err}
@@ -111,9 +119,9 @@ func (d *domainClient) GetMetadata(ctx context.Context, args *GetMetadataArgs) (
 func (d *domainClient) RequestDatabase(ctx context.Context, args *RequestDatabaseArgs) (reply *RequestDatabaseReply, err error) {
 	reply = new(RequestDatabaseReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.requestDatabase", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.requestDatabase", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.requestDatabase", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.requestDatabase", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "RequestDatabase", Err: err}
@@ -126,9 +134,9 @@ func (d *domainClient) RequestDatabase(ctx context.Context, args *RequestDatabas
 func (d *domainClient) RequestDatabaseNames(ctx context.Context, args *RequestDatabaseNamesArgs) (reply *RequestDatabaseNamesReply, err error) {
 	reply = new(RequestDatabaseNamesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IndexedDB.requestDatabaseNames", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.requestDatabaseNames", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IndexedDB.requestDatabaseNames", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IndexedDB.requestDatabaseNames", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IndexedDB", Op: "RequestDatabaseNames", Err: err}

--- a/protocol/input/domain.go
+++ b/protocol/input/domain.go
@@ -11,20 +11,28 @@ import (
 )
 
 // domainClient is a client for the Input domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Input domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Input domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // DispatchKeyEvent invokes the Input method. Dispatches a key event to the
 // page.
 func (d *domainClient) DispatchKeyEvent(ctx context.Context, args *DispatchKeyEventArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.dispatchKeyEvent", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.dispatchKeyEvent", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.dispatchKeyEvent", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.dispatchKeyEvent", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "DispatchKeyEvent", Err: err}
@@ -36,9 +44,9 @@ func (d *domainClient) DispatchKeyEvent(ctx context.Context, args *DispatchKeyEv
 // that doesn't come from a key press, for example an emoji keyboard or an IME.
 func (d *domainClient) InsertText(ctx context.Context, args *InsertTextArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.insertText", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.insertText", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.insertText", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.insertText", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "InsertText", Err: err}
@@ -50,9 +58,9 @@ func (d *domainClient) InsertText(ctx context.Context, args *InsertTextArgs) (er
 // the page.
 func (d *domainClient) DispatchMouseEvent(ctx context.Context, args *DispatchMouseEventArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.dispatchMouseEvent", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.dispatchMouseEvent", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.dispatchMouseEvent", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.dispatchMouseEvent", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "DispatchMouseEvent", Err: err}
@@ -64,9 +72,9 @@ func (d *domainClient) DispatchMouseEvent(ctx context.Context, args *DispatchMou
 // the page.
 func (d *domainClient) DispatchTouchEvent(ctx context.Context, args *DispatchTouchEventArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.dispatchTouchEvent", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.dispatchTouchEvent", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.dispatchTouchEvent", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.dispatchTouchEvent", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "DispatchTouchEvent", Err: err}
@@ -78,9 +86,9 @@ func (d *domainClient) DispatchTouchEvent(ctx context.Context, args *DispatchTou
 // from the mouse event parameters.
 func (d *domainClient) EmulateTouchFromMouseEvent(ctx context.Context, args *EmulateTouchFromMouseEventArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.emulateTouchFromMouseEvent", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.emulateTouchFromMouseEvent", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.emulateTouchFromMouseEvent", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.emulateTouchFromMouseEvent", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "EmulateTouchFromMouseEvent", Err: err}
@@ -92,9 +100,9 @@ func (d *domainClient) EmulateTouchFromMouseEvent(ctx context.Context, args *Emu
 // while auditing page).
 func (d *domainClient) SetIgnoreInputEvents(ctx context.Context, args *SetIgnoreInputEventsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.setIgnoreInputEvents", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.setIgnoreInputEvents", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.setIgnoreInputEvents", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.setIgnoreInputEvents", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "SetIgnoreInputEvents", Err: err}
@@ -106,9 +114,9 @@ func (d *domainClient) SetIgnoreInputEvents(ctx context.Context, args *SetIgnore
 // gesture over a time period by issuing appropriate touch events.
 func (d *domainClient) SynthesizePinchGesture(ctx context.Context, args *SynthesizePinchGestureArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.synthesizePinchGesture", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.synthesizePinchGesture", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.synthesizePinchGesture", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.synthesizePinchGesture", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "SynthesizePinchGesture", Err: err}
@@ -120,9 +128,9 @@ func (d *domainClient) SynthesizePinchGesture(ctx context.Context, args *Synthes
 // gesture over a time period by issuing appropriate touch events.
 func (d *domainClient) SynthesizeScrollGesture(ctx context.Context, args *SynthesizeScrollGestureArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.synthesizeScrollGesture", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.synthesizeScrollGesture", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.synthesizeScrollGesture", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.synthesizeScrollGesture", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "SynthesizeScrollGesture", Err: err}
@@ -134,9 +142,9 @@ func (d *domainClient) SynthesizeScrollGesture(ctx context.Context, args *Synthe
 // over a time period by issuing appropriate touch events.
 func (d *domainClient) SynthesizeTapGesture(ctx context.Context, args *SynthesizeTapGestureArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Input.synthesizeTapGesture", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.synthesizeTapGesture", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Input.synthesizeTapGesture", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Input.synthesizeTapGesture", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Input", Op: "SynthesizeTapGesture", Err: err}

--- a/protocol/inspector/domain.go
+++ b/protocol/inspector/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the Inspector domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Inspector domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Inspector domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Inspector method. Disables inspector domain
 // notifications.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Inspector.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Inspector.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Inspector", Op: "Disable", Err: err}
 	}
@@ -31,7 +39,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Enable invokes the Inspector method. Enables inspector domain
 // notifications.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Inspector.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Inspector.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Inspector", Op: "Enable", Err: err}
 	}
@@ -39,7 +47,7 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 }
 
 func (d *domainClient) Detached(ctx context.Context) (DetachedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Inspector.detached", d.conn)
+	s, err := rpcc.NewStream(ctx, "Inspector.detached", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +68,7 @@ func (c *detachedClient) Recv() (*DetachedReply, error) {
 }
 
 func (d *domainClient) TargetCrashed(ctx context.Context) (TargetCrashedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Inspector.targetCrashed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Inspector.targetCrashed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +89,7 @@ func (c *targetCrashedClient) Recv() (*TargetCrashedReply, error) {
 }
 
 func (d *domainClient) TargetReloadedAfterCrash(ctx context.Context) (TargetReloadedAfterCrashClient, error) {
-	s, err := rpcc.NewStream(ctx, "Inspector.targetReloadedAfterCrash", d.conn)
+	s, err := rpcc.NewStream(ctx, "Inspector.targetReloadedAfterCrash", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/io/domain.go
+++ b/protocol/io/domain.go
@@ -13,20 +13,28 @@ import (
 
 // domainClient is a client for the IO domain. Input/Output operations for
 // streams produced by DevTools.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the IO domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the IO domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Close invokes the IO method. Close the stream, discard any temporary
 // backing storage.
 func (d *domainClient) Close(ctx context.Context, args *CloseArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IO.close", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IO.close", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IO.close", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IO.close", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IO", Op: "Close", Err: err}
@@ -38,9 +46,9 @@ func (d *domainClient) Close(ctx context.Context, args *CloseArgs) (err error) {
 func (d *domainClient) Read(ctx context.Context, args *ReadArgs) (reply *ReadReply, err error) {
 	reply = new(ReadReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IO.read", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IO.read", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IO.read", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IO.read", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IO", Op: "Read", Err: err}
@@ -53,9 +61,9 @@ func (d *domainClient) Read(ctx context.Context, args *ReadArgs) (reply *ReadRep
 func (d *domainClient) ResolveBlob(ctx context.Context, args *ResolveBlobArgs) (reply *ResolveBlobReply, err error) {
 	reply = new(ResolveBlobReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "IO.resolveBlob", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IO.resolveBlob", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "IO.resolveBlob", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "IO.resolveBlob", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "IO", Op: "ResolveBlob", Err: err}

--- a/protocol/layertree/domain.go
+++ b/protocol/layertree/domain.go
@@ -11,11 +11,19 @@ import (
 )
 
 // domainClient is a client for the LayerTree domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the LayerTree domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the LayerTree domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // CompositingReasons invokes the LayerTree method. Provides the reasons why
@@ -23,9 +31,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) CompositingReasons(ctx context.Context, args *CompositingReasonsArgs) (reply *CompositingReasonsReply, err error) {
 	reply = new(CompositingReasonsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.compositingReasons", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.compositingReasons", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.compositingReasons", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.compositingReasons", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "CompositingReasons", Err: err}
@@ -35,7 +43,7 @@ func (d *domainClient) CompositingReasons(ctx context.Context, args *Compositing
 
 // Disable invokes the LayerTree method. Disables compositing tree inspection.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "LayerTree.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "LayerTree.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "Disable", Err: err}
 	}
@@ -44,7 +52,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 
 // Enable invokes the LayerTree method. Enables compositing tree inspection.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "LayerTree.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "LayerTree.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "Enable", Err: err}
 	}
@@ -55,9 +63,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) LoadSnapshot(ctx context.Context, args *LoadSnapshotArgs) (reply *LoadSnapshotReply, err error) {
 	reply = new(LoadSnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.loadSnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.loadSnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.loadSnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.loadSnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "LoadSnapshot", Err: err}
@@ -70,9 +78,9 @@ func (d *domainClient) LoadSnapshot(ctx context.Context, args *LoadSnapshotArgs)
 func (d *domainClient) MakeSnapshot(ctx context.Context, args *MakeSnapshotArgs) (reply *MakeSnapshotReply, err error) {
 	reply = new(MakeSnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.makeSnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.makeSnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.makeSnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.makeSnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "MakeSnapshot", Err: err}
@@ -84,9 +92,9 @@ func (d *domainClient) MakeSnapshot(ctx context.Context, args *MakeSnapshotArgs)
 func (d *domainClient) ProfileSnapshot(ctx context.Context, args *ProfileSnapshotArgs) (reply *ProfileSnapshotReply, err error) {
 	reply = new(ProfileSnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.profileSnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.profileSnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.profileSnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.profileSnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "ProfileSnapshot", Err: err}
@@ -98,9 +106,9 @@ func (d *domainClient) ProfileSnapshot(ctx context.Context, args *ProfileSnapsho
 // captured by the back-end.
 func (d *domainClient) ReleaseSnapshot(ctx context.Context, args *ReleaseSnapshotArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.releaseSnapshot", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.releaseSnapshot", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.releaseSnapshot", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.releaseSnapshot", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "ReleaseSnapshot", Err: err}
@@ -113,9 +121,9 @@ func (d *domainClient) ReleaseSnapshot(ctx context.Context, args *ReleaseSnapsho
 func (d *domainClient) ReplaySnapshot(ctx context.Context, args *ReplaySnapshotArgs) (reply *ReplaySnapshotReply, err error) {
 	reply = new(ReplaySnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.replaySnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.replaySnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.replaySnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.replaySnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "ReplaySnapshot", Err: err}
@@ -128,9 +136,9 @@ func (d *domainClient) ReplaySnapshot(ctx context.Context, args *ReplaySnapshotA
 func (d *domainClient) SnapshotCommandLog(ctx context.Context, args *SnapshotCommandLogArgs) (reply *SnapshotCommandLogReply, err error) {
 	reply = new(SnapshotCommandLogReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "LayerTree.snapshotCommandLog", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.snapshotCommandLog", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "LayerTree.snapshotCommandLog", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "LayerTree.snapshotCommandLog", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "LayerTree", Op: "SnapshotCommandLog", Err: err}
@@ -139,7 +147,7 @@ func (d *domainClient) SnapshotCommandLog(ctx context.Context, args *SnapshotCom
 }
 
 func (d *domainClient) LayerPainted(ctx context.Context) (LayerPaintedClient, error) {
-	s, err := rpcc.NewStream(ctx, "LayerTree.layerPainted", d.conn)
+	s, err := rpcc.NewStream(ctx, "LayerTree.layerPainted", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +168,7 @@ func (c *layerPaintedClient) Recv() (*LayerPaintedReply, error) {
 }
 
 func (d *domainClient) LayerTreeDidChange(ctx context.Context) (DidChangeClient, error) {
-	s, err := rpcc.NewStream(ctx, "LayerTree.layerTreeDidChange", d.conn)
+	s, err := rpcc.NewStream(ctx, "LayerTree.layerTreeDidChange", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/log/domain.go
+++ b/protocol/log/domain.go
@@ -12,16 +12,24 @@ import (
 
 // domainClient is a client for the Log domain. Provides access to log
 // entries.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Log domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Log domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Clear invokes the Log method. Clears the log.
 func (d *domainClient) Clear(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Log.clear", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Log.clear", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Log", Op: "Clear", Err: err}
 	}
@@ -31,7 +39,7 @@ func (d *domainClient) Clear(ctx context.Context) (err error) {
 // Disable invokes the Log method. Disables log domain, prevents further log
 // entries from being reported to the client.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Log.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Log.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Log", Op: "Disable", Err: err}
 	}
@@ -41,7 +49,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Enable invokes the Log method. Enables log domain, sends the entries
 // collected so far to the client by means of the `entryAdded` notification.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Log.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Log.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Log", Op: "Enable", Err: err}
 	}
@@ -51,9 +59,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // StartViolationsReport invokes the Log method. start violation reporting.
 func (d *domainClient) StartViolationsReport(ctx context.Context, args *StartViolationsReportArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Log.startViolationsReport", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Log.startViolationsReport", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Log.startViolationsReport", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Log.startViolationsReport", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Log", Op: "StartViolationsReport", Err: err}
@@ -63,7 +71,7 @@ func (d *domainClient) StartViolationsReport(ctx context.Context, args *StartVio
 
 // StopViolationsReport invokes the Log method. Stop violation reporting.
 func (d *domainClient) StopViolationsReport(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Log.stopViolationsReport", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Log.stopViolationsReport", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Log", Op: "StopViolationsReport", Err: err}
 	}
@@ -71,7 +79,7 @@ func (d *domainClient) StopViolationsReport(ctx context.Context) (err error) {
 }
 
 func (d *domainClient) EntryAdded(ctx context.Context) (EntryAddedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Log.entryAdded", d.conn)
+	s, err := rpcc.NewStream(ctx, "Log.entryAdded", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/memory/domain.go
+++ b/protocol/memory/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the Memory domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Memory domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Memory domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // GetDOMCounters invokes the Memory method.
 func (d *domainClient) GetDOMCounters(ctx context.Context) (reply *GetDOMCountersReply, err error) {
 	reply = new(GetDOMCountersReply)
-	err = rpcc.Invoke(ctx, "Memory.getDOMCounters", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.getDOMCounters", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "GetDOMCounters", Err: err}
 	}
@@ -30,7 +38,7 @@ func (d *domainClient) GetDOMCounters(ctx context.Context) (reply *GetDOMCounter
 
 // PrepareForLeakDetection invokes the Memory method.
 func (d *domainClient) PrepareForLeakDetection(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Memory.prepareForLeakDetection", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.prepareForLeakDetection", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "PrepareForLeakDetection", Err: err}
 	}
@@ -40,7 +48,7 @@ func (d *domainClient) PrepareForLeakDetection(ctx context.Context) (err error) 
 // ForciblyPurgeJavaScriptMemory invokes the Memory method. Simulate
 // OomIntervention by purging V8 memory.
 func (d *domainClient) ForciblyPurgeJavaScriptMemory(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Memory.forciblyPurgeJavaScriptMemory", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.forciblyPurgeJavaScriptMemory", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "ForciblyPurgeJavaScriptMemory", Err: err}
 	}
@@ -51,9 +59,9 @@ func (d *domainClient) ForciblyPurgeJavaScriptMemory(ctx context.Context) (err e
 // Enable/disable suppressing memory pressure notifications in all processes.
 func (d *domainClient) SetPressureNotificationsSuppressed(ctx context.Context, args *SetPressureNotificationsSuppressedArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Memory.setPressureNotificationsSuppressed", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Memory.setPressureNotificationsSuppressed", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Memory.setPressureNotificationsSuppressed", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Memory.setPressureNotificationsSuppressed", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "SetPressureNotificationsSuppressed", Err: err}
@@ -65,9 +73,9 @@ func (d *domainClient) SetPressureNotificationsSuppressed(ctx context.Context, a
 // pressure notification in all processes.
 func (d *domainClient) SimulatePressureNotification(ctx context.Context, args *SimulatePressureNotificationArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Memory.simulatePressureNotification", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Memory.simulatePressureNotification", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Memory.simulatePressureNotification", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Memory.simulatePressureNotification", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "SimulatePressureNotification", Err: err}
@@ -79,9 +87,9 @@ func (d *domainClient) SimulatePressureNotification(ctx context.Context, args *S
 // profile.
 func (d *domainClient) StartSampling(ctx context.Context, args *StartSamplingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Memory.startSampling", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Memory.startSampling", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Memory.startSampling", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Memory.startSampling", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "StartSampling", Err: err}
@@ -92,7 +100,7 @@ func (d *domainClient) StartSampling(ctx context.Context, args *StartSamplingArg
 // StopSampling invokes the Memory method. Stop collecting native memory
 // profile.
 func (d *domainClient) StopSampling(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Memory.stopSampling", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.stopSampling", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "StopSampling", Err: err}
 	}
@@ -103,7 +111,7 @@ func (d *domainClient) StopSampling(ctx context.Context) (err error) {
 // allocations profile collected since renderer process startup.
 func (d *domainClient) GetAllTimeSamplingProfile(ctx context.Context) (reply *GetAllTimeSamplingProfileReply, err error) {
 	reply = new(GetAllTimeSamplingProfileReply)
-	err = rpcc.Invoke(ctx, "Memory.getAllTimeSamplingProfile", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.getAllTimeSamplingProfile", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "GetAllTimeSamplingProfile", Err: err}
 	}
@@ -114,7 +122,7 @@ func (d *domainClient) GetAllTimeSamplingProfile(ctx context.Context) (reply *Ge
 // allocations profile collected since browser process startup.
 func (d *domainClient) GetBrowserSamplingProfile(ctx context.Context) (reply *GetBrowserSamplingProfileReply, err error) {
 	reply = new(GetBrowserSamplingProfileReply)
-	err = rpcc.Invoke(ctx, "Memory.getBrowserSamplingProfile", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.getBrowserSamplingProfile", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "GetBrowserSamplingProfile", Err: err}
 	}
@@ -125,7 +133,7 @@ func (d *domainClient) GetBrowserSamplingProfile(ctx context.Context) (reply *Ge
 // allocations profile collected since last `startSampling` call.
 func (d *domainClient) GetSamplingProfile(ctx context.Context) (reply *GetSamplingProfileReply, err error) {
 	reply = new(GetSamplingProfileReply)
-	err = rpcc.Invoke(ctx, "Memory.getSamplingProfile", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Memory.getSamplingProfile", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Memory", Op: "GetSamplingProfile", Err: err}
 	}

--- a/protocol/network/domain.go
+++ b/protocol/network/domain.go
@@ -17,18 +17,26 @@ import (
 // tracking network activities of the page. It exposes information about http,
 // file, data and other requests and responses, their headers, bodies, timing,
 // etc.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Network domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Network domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // CanClearBrowserCache invokes the Network method. Tells whether clearing
 // browser cache is supported.
 func (d *domainClient) CanClearBrowserCache(ctx context.Context) (reply *CanClearBrowserCacheReply, err error) {
 	reply = new(CanClearBrowserCacheReply)
-	err = rpcc.Invoke(ctx, "Network.canClearBrowserCache", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.canClearBrowserCache", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "CanClearBrowserCache", Err: err}
 	}
@@ -39,7 +47,7 @@ func (d *domainClient) CanClearBrowserCache(ctx context.Context) (reply *CanClea
 // browser cookies is supported.
 func (d *domainClient) CanClearBrowserCookies(ctx context.Context) (reply *CanClearBrowserCookiesReply, err error) {
 	reply = new(CanClearBrowserCookiesReply)
-	err = rpcc.Invoke(ctx, "Network.canClearBrowserCookies", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.canClearBrowserCookies", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "CanClearBrowserCookies", Err: err}
 	}
@@ -50,7 +58,7 @@ func (d *domainClient) CanClearBrowserCookies(ctx context.Context) (reply *CanCl
 // emulation of network conditions is supported.
 func (d *domainClient) CanEmulateNetworkConditions(ctx context.Context) (reply *CanEmulateNetworkConditionsReply, err error) {
 	reply = new(CanEmulateNetworkConditionsReply)
-	err = rpcc.Invoke(ctx, "Network.canEmulateNetworkConditions", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.canEmulateNetworkConditions", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "CanEmulateNetworkConditions", Err: err}
 	}
@@ -59,7 +67,7 @@ func (d *domainClient) CanEmulateNetworkConditions(ctx context.Context) (reply *
 
 // ClearBrowserCache invokes the Network method. Clears browser cache.
 func (d *domainClient) ClearBrowserCache(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Network.clearBrowserCache", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.clearBrowserCache", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "ClearBrowserCache", Err: err}
 	}
@@ -68,7 +76,7 @@ func (d *domainClient) ClearBrowserCache(ctx context.Context) (err error) {
 
 // ClearBrowserCookies invokes the Network method. Clears browser cookies.
 func (d *domainClient) ClearBrowserCookies(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Network.clearBrowserCookies", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.clearBrowserCookies", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "ClearBrowserCookies", Err: err}
 	}
@@ -84,9 +92,9 @@ func (d *domainClient) ClearBrowserCookies(ctx context.Context) (err error) {
 // Fetch.fulfillRequest and Fetch.failRequest instead.
 func (d *domainClient) ContinueInterceptedRequest(ctx context.Context, args *ContinueInterceptedRequestArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.continueInterceptedRequest", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.continueInterceptedRequest", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.continueInterceptedRequest", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.continueInterceptedRequest", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "ContinueInterceptedRequest", Err: err}
@@ -98,9 +106,9 @@ func (d *domainClient) ContinueInterceptedRequest(ctx context.Context, args *Con
 // matching name and url or domain/path pair.
 func (d *domainClient) DeleteCookies(ctx context.Context, args *DeleteCookiesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.deleteCookies", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.deleteCookies", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.deleteCookies", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.deleteCookies", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "DeleteCookies", Err: err}
@@ -111,7 +119,7 @@ func (d *domainClient) DeleteCookies(ctx context.Context, args *DeleteCookiesArg
 // Disable invokes the Network method. Disables network tracking, prevents
 // network events from being sent to the client.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Network.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "Disable", Err: err}
 	}
@@ -122,9 +130,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // network conditions.
 func (d *domainClient) EmulateNetworkConditions(ctx context.Context, args *EmulateNetworkConditionsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.emulateNetworkConditions", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.emulateNetworkConditions", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.emulateNetworkConditions", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.emulateNetworkConditions", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "EmulateNetworkConditions", Err: err}
@@ -136,9 +144,9 @@ func (d *domainClient) EmulateNetworkConditions(ctx context.Context, args *Emula
 // will now be delivered to the client.
 func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.enable", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.enable", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.enable", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.enable", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "Enable", Err: err}
@@ -151,7 +159,7 @@ func (d *domainClient) Enable(ctx context.Context, args *EnableArgs) (err error)
 // the `cookies` field.
 func (d *domainClient) GetAllCookies(ctx context.Context) (reply *GetAllCookiesReply, err error) {
 	reply = new(GetAllCookiesReply)
-	err = rpcc.Invoke(ctx, "Network.getAllCookies", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Network.getAllCookies", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "GetAllCookies", Err: err}
 	}
@@ -163,9 +171,9 @@ func (d *domainClient) GetAllCookies(ctx context.Context) (reply *GetAllCookiesR
 func (d *domainClient) GetCertificate(ctx context.Context, args *GetCertificateArgs) (reply *GetCertificateReply, err error) {
 	reply = new(GetCertificateReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.getCertificate", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getCertificate", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.getCertificate", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getCertificate", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "GetCertificate", Err: err}
@@ -179,9 +187,9 @@ func (d *domainClient) GetCertificate(ctx context.Context, args *GetCertificateA
 func (d *domainClient) GetCookies(ctx context.Context, args *GetCookiesArgs) (reply *GetCookiesReply, err error) {
 	reply = new(GetCookiesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.getCookies", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getCookies", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.getCookies", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getCookies", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "GetCookies", Err: err}
@@ -194,9 +202,9 @@ func (d *domainClient) GetCookies(ctx context.Context, args *GetCookiesArgs) (re
 func (d *domainClient) GetResponseBody(ctx context.Context, args *GetResponseBodyArgs) (reply *GetResponseBodyReply, err error) {
 	reply = new(GetResponseBodyReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.getResponseBody", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getResponseBody", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.getResponseBody", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getResponseBody", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "GetResponseBody", Err: err}
@@ -209,9 +217,9 @@ func (d *domainClient) GetResponseBody(ctx context.Context, args *GetResponseBod
 func (d *domainClient) GetRequestPostData(ctx context.Context, args *GetRequestPostDataArgs) (reply *GetRequestPostDataReply, err error) {
 	reply = new(GetRequestPostDataReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.getRequestPostData", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getRequestPostData", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.getRequestPostData", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getRequestPostData", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "GetRequestPostData", Err: err}
@@ -224,9 +232,9 @@ func (d *domainClient) GetRequestPostData(ctx context.Context, args *GetRequestP
 func (d *domainClient) GetResponseBodyForInterception(ctx context.Context, args *GetResponseBodyForInterceptionArgs) (reply *GetResponseBodyForInterceptionReply, err error) {
 	reply = new(GetResponseBodyForInterceptionReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.getResponseBodyForInterception", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getResponseBodyForInterception", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.getResponseBodyForInterception", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.getResponseBodyForInterception", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "GetResponseBodyForInterception", Err: err}
@@ -242,9 +250,9 @@ func (d *domainClient) GetResponseBodyForInterception(ctx context.Context, args 
 func (d *domainClient) TakeResponseBodyForInterceptionAsStream(ctx context.Context, args *TakeResponseBodyForInterceptionAsStreamArgs) (reply *TakeResponseBodyForInterceptionAsStreamReply, err error) {
 	reply = new(TakeResponseBodyForInterceptionAsStreamReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.takeResponseBodyForInterceptionAsStream", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.takeResponseBodyForInterceptionAsStream", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.takeResponseBodyForInterceptionAsStream", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.takeResponseBodyForInterceptionAsStream", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "TakeResponseBodyForInterceptionAsStream", Err: err}
@@ -258,9 +266,9 @@ func (d *domainClient) TakeResponseBodyForInterceptionAsStream(ctx context.Conte
 // headers, withCredentials attribute, user, password.
 func (d *domainClient) ReplayXHR(ctx context.Context, args *ReplayXHRArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.replayXHR", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.replayXHR", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.replayXHR", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.replayXHR", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "ReplayXHR", Err: err}
@@ -273,9 +281,9 @@ func (d *domainClient) ReplayXHR(ctx context.Context, args *ReplayXHRArgs) (err 
 func (d *domainClient) SearchInResponseBody(ctx context.Context, args *SearchInResponseBodyArgs) (reply *SearchInResponseBodyReply, err error) {
 	reply = new(SearchInResponseBodyReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.searchInResponseBody", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.searchInResponseBody", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.searchInResponseBody", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.searchInResponseBody", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SearchInResponseBody", Err: err}
@@ -286,9 +294,9 @@ func (d *domainClient) SearchInResponseBody(ctx context.Context, args *SearchInR
 // SetBlockedURLs invokes the Network method. Blocks URLs from loading.
 func (d *domainClient) SetBlockedURLs(ctx context.Context, args *SetBlockedURLsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setBlockedURLs", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setBlockedURLs", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setBlockedURLs", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setBlockedURLs", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetBlockedURLs", Err: err}
@@ -300,9 +308,9 @@ func (d *domainClient) SetBlockedURLs(ctx context.Context, args *SetBlockedURLsA
 // service worker for each request.
 func (d *domainClient) SetBypassServiceWorker(ctx context.Context, args *SetBypassServiceWorkerArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setBypassServiceWorker", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setBypassServiceWorker", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setBypassServiceWorker", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setBypassServiceWorker", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetBypassServiceWorker", Err: err}
@@ -314,9 +322,9 @@ func (d *domainClient) SetBypassServiceWorker(ctx context.Context, args *SetBypa
 // each request. If `true`, cache will not be used.
 func (d *domainClient) SetCacheDisabled(ctx context.Context, args *SetCacheDisabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setCacheDisabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setCacheDisabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setCacheDisabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setCacheDisabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetCacheDisabled", Err: err}
@@ -329,9 +337,9 @@ func (d *domainClient) SetCacheDisabled(ctx context.Context, args *SetCacheDisab
 func (d *domainClient) SetCookie(ctx context.Context, args *SetCookieArgs) (reply *SetCookieReply, err error) {
 	reply = new(SetCookieReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setCookie", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setCookie", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setCookie", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setCookie", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetCookie", Err: err}
@@ -342,9 +350,9 @@ func (d *domainClient) SetCookie(ctx context.Context, args *SetCookieArgs) (repl
 // SetCookies invokes the Network method. Sets given cookies.
 func (d *domainClient) SetCookies(ctx context.Context, args *SetCookiesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setCookies", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setCookies", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setCookies", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setCookies", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetCookies", Err: err}
@@ -355,9 +363,9 @@ func (d *domainClient) SetCookies(ctx context.Context, args *SetCookiesArgs) (er
 // SetDataSizeLimitsForTest invokes the Network method. For testing.
 func (d *domainClient) SetDataSizeLimitsForTest(ctx context.Context, args *SetDataSizeLimitsForTestArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setDataSizeLimitsForTest", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setDataSizeLimitsForTest", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setDataSizeLimitsForTest", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setDataSizeLimitsForTest", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetDataSizeLimitsForTest", Err: err}
@@ -369,9 +377,9 @@ func (d *domainClient) SetDataSizeLimitsForTest(ctx context.Context, args *SetDa
 // send extra HTTP headers with the requests from this page.
 func (d *domainClient) SetExtraHTTPHeaders(ctx context.Context, args *SetExtraHTTPHeadersArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setExtraHTTPHeaders", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setExtraHTTPHeaders", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setExtraHTTPHeaders", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setExtraHTTPHeaders", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetExtraHTTPHeaders", Err: err}
@@ -384,9 +392,9 @@ func (d *domainClient) SetExtraHTTPHeaders(ctx context.Context, args *SetExtraHT
 // Deprecated, please use Fetch.enable instead.
 func (d *domainClient) SetRequestInterception(ctx context.Context, args *SetRequestInterceptionArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Network.setRequestInterception", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setRequestInterception", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Network.setRequestInterception", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Network.setRequestInterception", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Network", Op: "SetRequestInterception", Err: err}
@@ -395,7 +403,7 @@ func (d *domainClient) SetRequestInterception(ctx context.Context, args *SetRequ
 }
 
 func (d *domainClient) DataReceived(ctx context.Context) (DataReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.dataReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.dataReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +424,7 @@ func (c *dataReceivedClient) Recv() (*DataReceivedReply, error) {
 }
 
 func (d *domainClient) EventSourceMessageReceived(ctx context.Context) (EventSourceMessageReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.eventSourceMessageReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.eventSourceMessageReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +445,7 @@ func (c *eventSourceMessageReceivedClient) Recv() (*EventSourceMessageReceivedRe
 }
 
 func (d *domainClient) LoadingFailed(ctx context.Context) (LoadingFailedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.loadingFailed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.loadingFailed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +466,7 @@ func (c *loadingFailedClient) Recv() (*LoadingFailedReply, error) {
 }
 
 func (d *domainClient) LoadingFinished(ctx context.Context) (LoadingFinishedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.loadingFinished", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.loadingFinished", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +487,7 @@ func (c *loadingFinishedClient) Recv() (*LoadingFinishedReply, error) {
 }
 
 func (d *domainClient) RequestIntercepted(ctx context.Context) (RequestInterceptedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.requestIntercepted", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.requestIntercepted", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +508,7 @@ func (c *requestInterceptedClient) Recv() (*RequestInterceptedReply, error) {
 }
 
 func (d *domainClient) RequestServedFromCache(ctx context.Context) (RequestServedFromCacheClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.requestServedFromCache", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.requestServedFromCache", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +529,7 @@ func (c *requestServedFromCacheClient) Recv() (*RequestServedFromCacheReply, err
 }
 
 func (d *domainClient) RequestWillBeSent(ctx context.Context) (RequestWillBeSentClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.requestWillBeSent", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.requestWillBeSent", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +550,7 @@ func (c *requestWillBeSentClient) Recv() (*RequestWillBeSentReply, error) {
 }
 
 func (d *domainClient) ResourceChangedPriority(ctx context.Context) (ResourceChangedPriorityClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.resourceChangedPriority", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.resourceChangedPriority", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +571,7 @@ func (c *resourceChangedPriorityClient) Recv() (*ResourceChangedPriorityReply, e
 }
 
 func (d *domainClient) SignedExchangeReceived(ctx context.Context) (SignedExchangeReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.signedExchangeReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.signedExchangeReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +592,7 @@ func (c *signedExchangeReceivedClient) Recv() (*SignedExchangeReceivedReply, err
 }
 
 func (d *domainClient) ResponseReceived(ctx context.Context) (ResponseReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.responseReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.responseReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +613,7 @@ func (c *responseReceivedClient) Recv() (*ResponseReceivedReply, error) {
 }
 
 func (d *domainClient) WebSocketClosed(ctx context.Context) (WebSocketClosedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketClosed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketClosed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +634,7 @@ func (c *webSocketClosedClient) Recv() (*WebSocketClosedReply, error) {
 }
 
 func (d *domainClient) WebSocketCreated(ctx context.Context) (WebSocketCreatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketCreated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketCreated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +655,7 @@ func (c *webSocketCreatedClient) Recv() (*WebSocketCreatedReply, error) {
 }
 
 func (d *domainClient) WebSocketFrameError(ctx context.Context) (WebSocketFrameErrorClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketFrameError", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketFrameError", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +676,7 @@ func (c *webSocketFrameErrorClient) Recv() (*WebSocketFrameErrorReply, error) {
 }
 
 func (d *domainClient) WebSocketFrameReceived(ctx context.Context) (WebSocketFrameReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketFrameReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketFrameReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -689,7 +697,7 @@ func (c *webSocketFrameReceivedClient) Recv() (*WebSocketFrameReceivedReply, err
 }
 
 func (d *domainClient) WebSocketFrameSent(ctx context.Context) (WebSocketFrameSentClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketFrameSent", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketFrameSent", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +718,7 @@ func (c *webSocketFrameSentClient) Recv() (*WebSocketFrameSentReply, error) {
 }
 
 func (d *domainClient) WebSocketHandshakeResponseReceived(ctx context.Context) (WebSocketHandshakeResponseReceivedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketHandshakeResponseReceived", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketHandshakeResponseReceived", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +739,7 @@ func (c *webSocketHandshakeResponseReceivedClient) Recv() (*WebSocketHandshakeRe
 }
 
 func (d *domainClient) WebSocketWillSendHandshakeRequest(ctx context.Context) (WebSocketWillSendHandshakeRequestClient, error) {
-	s, err := rpcc.NewStream(ctx, "Network.webSocketWillSendHandshakeRequest", d.conn)
+	s, err := rpcc.NewStream(ctx, "Network.webSocketWillSendHandshakeRequest", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/overlay/domain.go
+++ b/protocol/overlay/domain.go
@@ -13,16 +13,24 @@ import (
 
 // domainClient is a client for the Overlay domain. This domain provides
 // various functionality related to drawing atop the inspected page.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Overlay domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Overlay domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Overlay method. Disables domain notifications.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Overlay.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Overlay.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "Disable", Err: err}
 	}
@@ -31,7 +39,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 
 // Enable invokes the Overlay method. Enables domain notifications.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Overlay.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Overlay.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "Enable", Err: err}
 	}
@@ -42,9 +50,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) GetHighlightObjectForTest(ctx context.Context, args *GetHighlightObjectForTestArgs) (reply *GetHighlightObjectForTestReply, err error) {
 	reply = new(GetHighlightObjectForTestReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.getHighlightObjectForTest", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.getHighlightObjectForTest", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.getHighlightObjectForTest", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.getHighlightObjectForTest", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "GetHighlightObjectForTest", Err: err}
@@ -54,7 +62,7 @@ func (d *domainClient) GetHighlightObjectForTest(ctx context.Context, args *GetH
 
 // HideHighlight invokes the Overlay method. Hides any highlight.
 func (d *domainClient) HideHighlight(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Overlay.hideHighlight", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Overlay.hideHighlight", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "HideHighlight", Err: err}
 	}
@@ -65,9 +73,9 @@ func (d *domainClient) HideHighlight(ctx context.Context) (err error) {
 // frame with given id.
 func (d *domainClient) HighlightFrame(ctx context.Context, args *HighlightFrameArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.highlightFrame", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightFrame", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.highlightFrame", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightFrame", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "HighlightFrame", Err: err}
@@ -80,9 +88,9 @@ func (d *domainClient) HighlightFrame(ctx context.Context, args *HighlightFrameA
 // be specified.
 func (d *domainClient) HighlightNode(ctx context.Context, args *HighlightNodeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.highlightNode", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightNode", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.highlightNode", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightNode", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "HighlightNode", Err: err}
@@ -94,9 +102,9 @@ func (d *domainClient) HighlightNode(ctx context.Context, args *HighlightNodeArg
 // Coordinates are absolute with respect to the main frame viewport.
 func (d *domainClient) HighlightQuad(ctx context.Context, args *HighlightQuadArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.highlightQuad", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightQuad", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.highlightQuad", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightQuad", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "HighlightQuad", Err: err}
@@ -108,9 +116,9 @@ func (d *domainClient) HighlightQuad(ctx context.Context, args *HighlightQuadArg
 // Coordinates are absolute with respect to the main frame viewport.
 func (d *domainClient) HighlightRect(ctx context.Context, args *HighlightRectArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.highlightRect", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightRect", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.highlightRect", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.highlightRect", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "HighlightRect", Err: err}
@@ -123,9 +131,9 @@ func (d *domainClient) HighlightRect(ctx context.Context, args *HighlightRectArg
 // generates 'inspectNodeRequested' event upon element selection.
 func (d *domainClient) SetInspectMode(ctx context.Context, args *SetInspectModeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setInspectMode", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setInspectMode", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setInspectMode", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setInspectMode", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetInspectMode", Err: err}
@@ -137,9 +145,9 @@ func (d *domainClient) SetInspectMode(ctx context.Context, args *SetInspectModeA
 // all frames detected to be ads.
 func (d *domainClient) SetShowAdHighlights(ctx context.Context, args *SetShowAdHighlightsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowAdHighlights", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowAdHighlights", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowAdHighlights", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowAdHighlights", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowAdHighlights", Err: err}
@@ -150,9 +158,9 @@ func (d *domainClient) SetShowAdHighlights(ctx context.Context, args *SetShowAdH
 // SetPausedInDebuggerMessage invokes the Overlay method.
 func (d *domainClient) SetPausedInDebuggerMessage(ctx context.Context, args *SetPausedInDebuggerMessageArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setPausedInDebuggerMessage", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setPausedInDebuggerMessage", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setPausedInDebuggerMessage", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setPausedInDebuggerMessage", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetPausedInDebuggerMessage", Err: err}
@@ -164,9 +172,9 @@ func (d *domainClient) SetPausedInDebuggerMessage(ctx context.Context, args *Set
 // debug borders on layers
 func (d *domainClient) SetShowDebugBorders(ctx context.Context, args *SetShowDebugBordersArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowDebugBorders", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowDebugBorders", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowDebugBorders", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowDebugBorders", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowDebugBorders", Err: err}
@@ -178,9 +186,9 @@ func (d *domainClient) SetShowDebugBorders(ctx context.Context, args *SetShowDeb
 // the FPS counter
 func (d *domainClient) SetShowFPSCounter(ctx context.Context, args *SetShowFPSCounterArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowFPSCounter", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowFPSCounter", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowFPSCounter", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowFPSCounter", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowFPSCounter", Err: err}
@@ -192,9 +200,9 @@ func (d *domainClient) SetShowFPSCounter(ctx context.Context, args *SetShowFPSCo
 // paint rectangles
 func (d *domainClient) SetShowPaintRects(ctx context.Context, args *SetShowPaintRectsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowPaintRects", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowPaintRects", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowPaintRects", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowPaintRects", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowPaintRects", Err: err}
@@ -206,9 +214,9 @@ func (d *domainClient) SetShowPaintRects(ctx context.Context, args *SetShowPaint
 // shows layout shift regions
 func (d *domainClient) SetShowLayoutShiftRegions(ctx context.Context, args *SetShowLayoutShiftRegionsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowLayoutShiftRegions", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowLayoutShiftRegions", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowLayoutShiftRegions", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowLayoutShiftRegions", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowLayoutShiftRegions", Err: err}
@@ -220,9 +228,9 @@ func (d *domainClient) SetShowLayoutShiftRegions(ctx context.Context, args *SetS
 // backend shows scroll bottleneck rects
 func (d *domainClient) SetShowScrollBottleneckRects(ctx context.Context, args *SetShowScrollBottleneckRectsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowScrollBottleneckRects", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowScrollBottleneckRects", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowScrollBottleneckRects", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowScrollBottleneckRects", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowScrollBottleneckRects", Err: err}
@@ -234,9 +242,9 @@ func (d *domainClient) SetShowScrollBottleneckRects(ctx context.Context, args *S
 // shows hit-test borders on layers
 func (d *domainClient) SetShowHitTestBorders(ctx context.Context, args *SetShowHitTestBordersArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowHitTestBorders", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowHitTestBorders", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowHitTestBorders", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowHitTestBorders", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowHitTestBorders", Err: err}
@@ -248,9 +256,9 @@ func (d *domainClient) SetShowHitTestBorders(ctx context.Context, args *SetShowH
 // size upon main frame resize.
 func (d *domainClient) SetShowViewportSizeOnResize(ctx context.Context, args *SetShowViewportSizeOnResizeArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Overlay.setShowViewportSizeOnResize", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowViewportSizeOnResize", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Overlay.setShowViewportSizeOnResize", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Overlay.setShowViewportSizeOnResize", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Overlay", Op: "SetShowViewportSizeOnResize", Err: err}
@@ -259,7 +267,7 @@ func (d *domainClient) SetShowViewportSizeOnResize(ctx context.Context, args *Se
 }
 
 func (d *domainClient) InspectNodeRequested(ctx context.Context) (InspectNodeRequestedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Overlay.inspectNodeRequested", d.conn)
+	s, err := rpcc.NewStream(ctx, "Overlay.inspectNodeRequested", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +288,7 @@ func (c *inspectNodeRequestedClient) Recv() (*InspectNodeRequestedReply, error) 
 }
 
 func (d *domainClient) NodeHighlightRequested(ctx context.Context) (NodeHighlightRequestedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Overlay.nodeHighlightRequested", d.conn)
+	s, err := rpcc.NewStream(ctx, "Overlay.nodeHighlightRequested", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +309,7 @@ func (c *nodeHighlightRequestedClient) Recv() (*NodeHighlightRequestedReply, err
 }
 
 func (d *domainClient) ScreenshotRequested(ctx context.Context) (ScreenshotRequestedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Overlay.screenshotRequested", d.conn)
+	s, err := rpcc.NewStream(ctx, "Overlay.screenshotRequested", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +330,7 @@ func (c *screenshotRequestedClient) Recv() (*ScreenshotRequestedReply, error) {
 }
 
 func (d *domainClient) InspectModeCanceled(ctx context.Context) (InspectModeCanceledClient, error) {
-	s, err := rpcc.NewStream(ctx, "Overlay.inspectModeCanceled", d.conn)
+	s, err := rpcc.NewStream(ctx, "Overlay.inspectModeCanceled", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/page/domain.go
+++ b/protocol/page/domain.go
@@ -13,11 +13,19 @@ import (
 
 // domainClient is a client for the Page domain. Actions and events related to
 // the inspected page belong to the page domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Page domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the Page domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // AddScriptToEvaluateOnLoad invokes the Page method. Deprecated, please use
@@ -25,9 +33,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) AddScriptToEvaluateOnLoad(ctx context.Context, args *AddScriptToEvaluateOnLoadArgs) (reply *AddScriptToEvaluateOnLoadReply, err error) {
 	reply = new(AddScriptToEvaluateOnLoadReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.addScriptToEvaluateOnLoad", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.addScriptToEvaluateOnLoad", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.addScriptToEvaluateOnLoad", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.addScriptToEvaluateOnLoad", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "AddScriptToEvaluateOnLoad", Err: err}
@@ -40,9 +48,9 @@ func (d *domainClient) AddScriptToEvaluateOnLoad(ctx context.Context, args *AddS
 func (d *domainClient) AddScriptToEvaluateOnNewDocument(ctx context.Context, args *AddScriptToEvaluateOnNewDocumentArgs) (reply *AddScriptToEvaluateOnNewDocumentReply, err error) {
 	reply = new(AddScriptToEvaluateOnNewDocumentReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.addScriptToEvaluateOnNewDocument", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.addScriptToEvaluateOnNewDocument", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.addScriptToEvaluateOnNewDocument", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.addScriptToEvaluateOnNewDocument", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "AddScriptToEvaluateOnNewDocument", Err: err}
@@ -52,7 +60,7 @@ func (d *domainClient) AddScriptToEvaluateOnNewDocument(ctx context.Context, arg
 
 // BringToFront invokes the Page method. Brings page to front (activates tab).
 func (d *domainClient) BringToFront(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.bringToFront", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.bringToFront", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "BringToFront", Err: err}
 	}
@@ -63,9 +71,9 @@ func (d *domainClient) BringToFront(ctx context.Context) (err error) {
 func (d *domainClient) CaptureScreenshot(ctx context.Context, args *CaptureScreenshotArgs) (reply *CaptureScreenshotReply, err error) {
 	reply = new(CaptureScreenshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.captureScreenshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.captureScreenshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.captureScreenshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.captureScreenshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "CaptureScreenshot", Err: err}
@@ -79,9 +87,9 @@ func (d *domainClient) CaptureScreenshot(ctx context.Context, args *CaptureScree
 func (d *domainClient) CaptureSnapshot(ctx context.Context, args *CaptureSnapshotArgs) (reply *CaptureSnapshotReply, err error) {
 	reply = new(CaptureSnapshotReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.captureSnapshot", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.captureSnapshot", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.captureSnapshot", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.captureSnapshot", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "CaptureSnapshot", Err: err}
@@ -94,9 +102,9 @@ func (d *domainClient) CaptureSnapshot(ctx context.Context, args *CaptureSnapsho
 func (d *domainClient) CreateIsolatedWorld(ctx context.Context, args *CreateIsolatedWorldArgs) (reply *CreateIsolatedWorldReply, err error) {
 	reply = new(CreateIsolatedWorldReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.createIsolatedWorld", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.createIsolatedWorld", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.createIsolatedWorld", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.createIsolatedWorld", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "CreateIsolatedWorld", Err: err}
@@ -106,7 +114,7 @@ func (d *domainClient) CreateIsolatedWorld(ctx context.Context, args *CreateIsol
 
 // Disable invokes the Page method. Disables page domain notifications.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "Disable", Err: err}
 	}
@@ -115,7 +123,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 
 // Enable invokes the Page method. Enables page domain notifications.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "Enable", Err: err}
 	}
@@ -125,7 +133,7 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // GetAppManifest invokes the Page method.
 func (d *domainClient) GetAppManifest(ctx context.Context) (reply *GetAppManifestReply, err error) {
 	reply = new(GetAppManifestReply)
-	err = rpcc.Invoke(ctx, "Page.getAppManifest", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.getAppManifest", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetAppManifest", Err: err}
 	}
@@ -135,7 +143,7 @@ func (d *domainClient) GetAppManifest(ctx context.Context) (reply *GetAppManifes
 // GetInstallabilityErrors invokes the Page method.
 func (d *domainClient) GetInstallabilityErrors(ctx context.Context) (reply *GetInstallabilityErrorsReply, err error) {
 	reply = new(GetInstallabilityErrorsReply)
-	err = rpcc.Invoke(ctx, "Page.getInstallabilityErrors", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.getInstallabilityErrors", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetInstallabilityErrors", Err: err}
 	}
@@ -145,7 +153,7 @@ func (d *domainClient) GetInstallabilityErrors(ctx context.Context) (reply *GetI
 // GetFrameTree invokes the Page method. Returns present frame tree structure.
 func (d *domainClient) GetFrameTree(ctx context.Context) (reply *GetFrameTreeReply, err error) {
 	reply = new(GetFrameTreeReply)
-	err = rpcc.Invoke(ctx, "Page.getFrameTree", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.getFrameTree", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetFrameTree", Err: err}
 	}
@@ -156,7 +164,7 @@ func (d *domainClient) GetFrameTree(ctx context.Context) (reply *GetFrameTreeRep
 // layouting of the page, such as viewport bounds/scale.
 func (d *domainClient) GetLayoutMetrics(ctx context.Context) (reply *GetLayoutMetricsReply, err error) {
 	reply = new(GetLayoutMetricsReply)
-	err = rpcc.Invoke(ctx, "Page.getLayoutMetrics", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.getLayoutMetrics", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetLayoutMetrics", Err: err}
 	}
@@ -167,7 +175,7 @@ func (d *domainClient) GetLayoutMetrics(ctx context.Context) (reply *GetLayoutMe
 // for the current page.
 func (d *domainClient) GetNavigationHistory(ctx context.Context) (reply *GetNavigationHistoryReply, err error) {
 	reply = new(GetNavigationHistoryReply)
-	err = rpcc.Invoke(ctx, "Page.getNavigationHistory", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.getNavigationHistory", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetNavigationHistory", Err: err}
 	}
@@ -177,7 +185,7 @@ func (d *domainClient) GetNavigationHistory(ctx context.Context) (reply *GetNavi
 // ResetNavigationHistory invokes the Page method. Resets navigation history
 // for the current page.
 func (d *domainClient) ResetNavigationHistory(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.resetNavigationHistory", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.resetNavigationHistory", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "ResetNavigationHistory", Err: err}
 	}
@@ -189,9 +197,9 @@ func (d *domainClient) ResetNavigationHistory(ctx context.Context) (err error) {
 func (d *domainClient) GetResourceContent(ctx context.Context, args *GetResourceContentArgs) (reply *GetResourceContentReply, err error) {
 	reply = new(GetResourceContentReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.getResourceContent", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.getResourceContent", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.getResourceContent", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.getResourceContent", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetResourceContent", Err: err}
@@ -203,7 +211,7 @@ func (d *domainClient) GetResourceContent(ctx context.Context, args *GetResource
 // tree structure.
 func (d *domainClient) GetResourceTree(ctx context.Context) (reply *GetResourceTreeReply, err error) {
 	reply = new(GetResourceTreeReply)
-	err = rpcc.Invoke(ctx, "Page.getResourceTree", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.getResourceTree", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GetResourceTree", Err: err}
 	}
@@ -214,9 +222,9 @@ func (d *domainClient) GetResourceTree(ctx context.Context) (reply *GetResourceT
 // JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).
 func (d *domainClient) HandleJavaScriptDialog(ctx context.Context, args *HandleJavaScriptDialogArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.handleJavaScriptDialog", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.handleJavaScriptDialog", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.handleJavaScriptDialog", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.handleJavaScriptDialog", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "HandleJavaScriptDialog", Err: err}
@@ -228,9 +236,9 @@ func (d *domainClient) HandleJavaScriptDialog(ctx context.Context, args *HandleJ
 func (d *domainClient) Navigate(ctx context.Context, args *NavigateArgs) (reply *NavigateReply, err error) {
 	reply = new(NavigateReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.navigate", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.navigate", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.navigate", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.navigate", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "Navigate", Err: err}
@@ -242,9 +250,9 @@ func (d *domainClient) Navigate(ctx context.Context, args *NavigateArgs) (reply 
 // the given history entry.
 func (d *domainClient) NavigateToHistoryEntry(ctx context.Context, args *NavigateToHistoryEntryArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.navigateToHistoryEntry", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.navigateToHistoryEntry", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.navigateToHistoryEntry", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.navigateToHistoryEntry", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "NavigateToHistoryEntry", Err: err}
@@ -256,9 +264,9 @@ func (d *domainClient) NavigateToHistoryEntry(ctx context.Context, args *Navigat
 func (d *domainClient) PrintToPDF(ctx context.Context, args *PrintToPDFArgs) (reply *PrintToPDFReply, err error) {
 	reply = new(PrintToPDFReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.printToPDF", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.printToPDF", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.printToPDF", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.printToPDF", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "PrintToPDF", Err: err}
@@ -270,9 +278,9 @@ func (d *domainClient) PrintToPDF(ctx context.Context, args *PrintToPDFArgs) (re
 // cache.
 func (d *domainClient) Reload(ctx context.Context, args *ReloadArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.reload", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.reload", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.reload", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.reload", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "Reload", Err: err}
@@ -284,9 +292,9 @@ func (d *domainClient) Reload(ctx context.Context, args *ReloadArgs) (err error)
 // use removeScriptToEvaluateOnNewDocument instead.
 func (d *domainClient) RemoveScriptToEvaluateOnLoad(ctx context.Context, args *RemoveScriptToEvaluateOnLoadArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.removeScriptToEvaluateOnLoad", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.removeScriptToEvaluateOnLoad", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.removeScriptToEvaluateOnLoad", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.removeScriptToEvaluateOnLoad", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "RemoveScriptToEvaluateOnLoad", Err: err}
@@ -298,9 +306,9 @@ func (d *domainClient) RemoveScriptToEvaluateOnLoad(ctx context.Context, args *R
 // script from the list.
 func (d *domainClient) RemoveScriptToEvaluateOnNewDocument(ctx context.Context, args *RemoveScriptToEvaluateOnNewDocumentArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.removeScriptToEvaluateOnNewDocument", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.removeScriptToEvaluateOnNewDocument", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.removeScriptToEvaluateOnNewDocument", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.removeScriptToEvaluateOnNewDocument", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "RemoveScriptToEvaluateOnNewDocument", Err: err}
@@ -312,9 +320,9 @@ func (d *domainClient) RemoveScriptToEvaluateOnNewDocument(ctx context.Context, 
 // frame has been received by the frontend.
 func (d *domainClient) ScreencastFrameAck(ctx context.Context, args *ScreencastFrameAckArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.screencastFrameAck", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.screencastFrameAck", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.screencastFrameAck", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.screencastFrameAck", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "ScreencastFrameAck", Err: err}
@@ -327,9 +335,9 @@ func (d *domainClient) ScreencastFrameAck(ctx context.Context, args *ScreencastF
 func (d *domainClient) SearchInResource(ctx context.Context, args *SearchInResourceArgs) (reply *SearchInResourceReply, err error) {
 	reply = new(SearchInResourceReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.searchInResource", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.searchInResource", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.searchInResource", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.searchInResource", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SearchInResource", Err: err}
@@ -341,9 +349,9 @@ func (d *domainClient) SearchInResource(ctx context.Context, args *SearchInResou
 // ad filter on all sites.
 func (d *domainClient) SetAdBlockingEnabled(ctx context.Context, args *SetAdBlockingEnabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setAdBlockingEnabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setAdBlockingEnabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setAdBlockingEnabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setAdBlockingEnabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetAdBlockingEnabled", Err: err}
@@ -355,9 +363,9 @@ func (d *domainClient) SetAdBlockingEnabled(ctx context.Context, args *SetAdBloc
 // by-passing.
 func (d *domainClient) SetBypassCSP(ctx context.Context, args *SetBypassCSPArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setBypassCSP", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setBypassCSP", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setBypassCSP", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setBypassCSP", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetBypassCSP", Err: err}
@@ -368,9 +376,9 @@ func (d *domainClient) SetBypassCSP(ctx context.Context, args *SetBypassCSPArgs)
 // SetFontFamilies invokes the Page method. Set generic font families.
 func (d *domainClient) SetFontFamilies(ctx context.Context, args *SetFontFamiliesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setFontFamilies", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setFontFamilies", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setFontFamilies", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setFontFamilies", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetFontFamilies", Err: err}
@@ -381,9 +389,9 @@ func (d *domainClient) SetFontFamilies(ctx context.Context, args *SetFontFamilie
 // SetFontSizes invokes the Page method. Set default font sizes.
 func (d *domainClient) SetFontSizes(ctx context.Context, args *SetFontSizesArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setFontSizes", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setFontSizes", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setFontSizes", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setFontSizes", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetFontSizes", Err: err}
@@ -395,9 +403,9 @@ func (d *domainClient) SetFontSizes(ctx context.Context, args *SetFontSizesArgs)
 // document's HTML.
 func (d *domainClient) SetDocumentContent(ctx context.Context, args *SetDocumentContentArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setDocumentContent", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setDocumentContent", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setDocumentContent", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setDocumentContent", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetDocumentContent", Err: err}
@@ -409,9 +417,9 @@ func (d *domainClient) SetDocumentContent(ctx context.Context, args *SetDocument
 // downloading a file.
 func (d *domainClient) SetDownloadBehavior(ctx context.Context, args *SetDownloadBehaviorArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setDownloadBehavior", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setDownloadBehavior", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setDownloadBehavior", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setDownloadBehavior", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetDownloadBehavior", Err: err}
@@ -423,9 +431,9 @@ func (d *domainClient) SetDownloadBehavior(ctx context.Context, args *SetDownloa
 // will emit lifecycle events.
 func (d *domainClient) SetLifecycleEventsEnabled(ctx context.Context, args *SetLifecycleEventsEnabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setLifecycleEventsEnabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setLifecycleEventsEnabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setLifecycleEventsEnabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setLifecycleEventsEnabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetLifecycleEventsEnabled", Err: err}
@@ -437,9 +445,9 @@ func (d *domainClient) SetLifecycleEventsEnabled(ctx context.Context, args *SetL
 // the `screencastFrame` event.
 func (d *domainClient) StartScreencast(ctx context.Context, args *StartScreencastArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.startScreencast", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.startScreencast", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.startScreencast", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.startScreencast", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "StartScreencast", Err: err}
@@ -450,7 +458,7 @@ func (d *domainClient) StartScreencast(ctx context.Context, args *StartScreencas
 // StopLoading invokes the Page method. Force the page stop all navigations
 // and pending resource fetches.
 func (d *domainClient) StopLoading(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.stopLoading", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.stopLoading", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "StopLoading", Err: err}
 	}
@@ -460,7 +468,7 @@ func (d *domainClient) StopLoading(ctx context.Context) (err error) {
 // Crash invokes the Page method. Crashes renderer on the IO thread, generates
 // minidumps.
 func (d *domainClient) Crash(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.crash", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.crash", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "Crash", Err: err}
 	}
@@ -470,7 +478,7 @@ func (d *domainClient) Crash(ctx context.Context) (err error) {
 // Close invokes the Page method. Tries to close page, running its
 // beforeunload hooks, if any.
 func (d *domainClient) Close(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.close", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.close", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "Close", Err: err}
 	}
@@ -482,9 +490,9 @@ func (d *domainClient) Close(ctx context.Context) (err error) {
 // according to: https://github.com/WICG/web-lifecycle/
 func (d *domainClient) SetWebLifecycleState(ctx context.Context, args *SetWebLifecycleStateArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setWebLifecycleState", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setWebLifecycleState", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setWebLifecycleState", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setWebLifecycleState", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetWebLifecycleState", Err: err}
@@ -495,7 +503,7 @@ func (d *domainClient) SetWebLifecycleState(ctx context.Context, args *SetWebLif
 // StopScreencast invokes the Page method. Stops sending each frame in the
 // `screencastFrame`.
 func (d *domainClient) StopScreencast(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.stopScreencast", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.stopScreencast", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "StopScreencast", Err: err}
 	}
@@ -506,9 +514,9 @@ func (d *domainClient) StopScreencast(ctx context.Context) (err error) {
 // cache to be generated for every subresource script.
 func (d *domainClient) SetProduceCompilationCache(ctx context.Context, args *SetProduceCompilationCacheArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setProduceCompilationCache", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setProduceCompilationCache", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setProduceCompilationCache", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setProduceCompilationCache", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetProduceCompilationCache", Err: err}
@@ -520,9 +528,9 @@ func (d *domainClient) SetProduceCompilationCache(ctx context.Context, args *Set
 // given url. Compilation cache does not survive cross-process navigation.
 func (d *domainClient) AddCompilationCache(ctx context.Context, args *AddCompilationCacheArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.addCompilationCache", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.addCompilationCache", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.addCompilationCache", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.addCompilationCache", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "AddCompilationCache", Err: err}
@@ -533,7 +541,7 @@ func (d *domainClient) AddCompilationCache(ctx context.Context, args *AddCompila
 // ClearCompilationCache invokes the Page method. Clears seeded compilation
 // cache.
 func (d *domainClient) ClearCompilationCache(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.clearCompilationCache", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.clearCompilationCache", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "ClearCompilationCache", Err: err}
 	}
@@ -543,9 +551,9 @@ func (d *domainClient) ClearCompilationCache(ctx context.Context) (err error) {
 // GenerateTestReport invokes the Page method. Generates a report for testing.
 func (d *domainClient) GenerateTestReport(ctx context.Context, args *GenerateTestReportArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.generateTestReport", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.generateTestReport", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.generateTestReport", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.generateTestReport", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "GenerateTestReport", Err: err}
@@ -556,7 +564,7 @@ func (d *domainClient) GenerateTestReport(ctx context.Context, args *GenerateTes
 // WaitForDebugger invokes the Page method. Pauses page execution. Can be
 // resumed using generic Runtime.runIfWaitingForDebugger.
 func (d *domainClient) WaitForDebugger(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Page.waitForDebugger", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Page.waitForDebugger", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "WaitForDebugger", Err: err}
 	}
@@ -570,9 +578,9 @@ func (d *domainClient) WaitForDebugger(ctx context.Context) (err error) {
 // handled with `page.handleFileChooser` command.
 func (d *domainClient) SetInterceptFileChooserDialog(ctx context.Context, args *SetInterceptFileChooserDialogArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.setInterceptFileChooserDialog", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setInterceptFileChooserDialog", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.setInterceptFileChooserDialog", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.setInterceptFileChooserDialog", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "SetInterceptFileChooserDialog", Err: err}
@@ -584,9 +592,9 @@ func (d *domainClient) SetInterceptFileChooserDialog(ctx context.Context, args *
 // intercepted file chooser dialog.
 func (d *domainClient) HandleFileChooser(ctx context.Context, args *HandleFileChooserArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Page.handleFileChooser", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.handleFileChooser", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Page.handleFileChooser", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Page.handleFileChooser", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Page", Op: "HandleFileChooser", Err: err}
@@ -595,7 +603,7 @@ func (d *domainClient) HandleFileChooser(ctx context.Context, args *HandleFileCh
 }
 
 func (d *domainClient) DOMContentEventFired(ctx context.Context) (DOMContentEventFiredClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.domContentEventFired", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.domContentEventFired", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +624,7 @@ func (c *dOMContentEventFiredClient) Recv() (*DOMContentEventFiredReply, error) 
 }
 
 func (d *domainClient) FileChooserOpened(ctx context.Context) (FileChooserOpenedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.fileChooserOpened", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.fileChooserOpened", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -637,7 +645,7 @@ func (c *fileChooserOpenedClient) Recv() (*FileChooserOpenedReply, error) {
 }
 
 func (d *domainClient) FrameAttached(ctx context.Context) (FrameAttachedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameAttached", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameAttached", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +666,7 @@ func (c *frameAttachedClient) Recv() (*FrameAttachedReply, error) {
 }
 
 func (d *domainClient) FrameClearedScheduledNavigation(ctx context.Context) (FrameClearedScheduledNavigationClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameClearedScheduledNavigation", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameClearedScheduledNavigation", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -679,7 +687,7 @@ func (c *frameClearedScheduledNavigationClient) Recv() (*FrameClearedScheduledNa
 }
 
 func (d *domainClient) FrameDetached(ctx context.Context) (FrameDetachedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameDetached", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameDetached", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -700,7 +708,7 @@ func (c *frameDetachedClient) Recv() (*FrameDetachedReply, error) {
 }
 
 func (d *domainClient) FrameNavigated(ctx context.Context) (FrameNavigatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameNavigated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameNavigated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +729,7 @@ func (c *frameNavigatedClient) Recv() (*FrameNavigatedReply, error) {
 }
 
 func (d *domainClient) FrameResized(ctx context.Context) (FrameResizedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameResized", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameResized", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +750,7 @@ func (c *frameResizedClient) Recv() (*FrameResizedReply, error) {
 }
 
 func (d *domainClient) FrameRequestedNavigation(ctx context.Context) (FrameRequestedNavigationClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameRequestedNavigation", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameRequestedNavigation", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +771,7 @@ func (c *frameRequestedNavigationClient) Recv() (*FrameRequestedNavigationReply,
 }
 
 func (d *domainClient) FrameScheduledNavigation(ctx context.Context) (FrameScheduledNavigationClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameScheduledNavigation", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameScheduledNavigation", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +792,7 @@ func (c *frameScheduledNavigationClient) Recv() (*FrameScheduledNavigationReply,
 }
 
 func (d *domainClient) FrameStartedLoading(ctx context.Context) (FrameStartedLoadingClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameStartedLoading", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameStartedLoading", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -805,7 +813,7 @@ func (c *frameStartedLoadingClient) Recv() (*FrameStartedLoadingReply, error) {
 }
 
 func (d *domainClient) FrameStoppedLoading(ctx context.Context) (FrameStoppedLoadingClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.frameStoppedLoading", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.frameStoppedLoading", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -826,7 +834,7 @@ func (c *frameStoppedLoadingClient) Recv() (*FrameStoppedLoadingReply, error) {
 }
 
 func (d *domainClient) DownloadWillBegin(ctx context.Context) (DownloadWillBeginClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.downloadWillBegin", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.downloadWillBegin", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +855,7 @@ func (c *downloadWillBeginClient) Recv() (*DownloadWillBeginReply, error) {
 }
 
 func (d *domainClient) InterstitialHidden(ctx context.Context) (InterstitialHiddenClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.interstitialHidden", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.interstitialHidden", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -868,7 +876,7 @@ func (c *interstitialHiddenClient) Recv() (*InterstitialHiddenReply, error) {
 }
 
 func (d *domainClient) InterstitialShown(ctx context.Context) (InterstitialShownClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.interstitialShown", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.interstitialShown", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -889,7 +897,7 @@ func (c *interstitialShownClient) Recv() (*InterstitialShownReply, error) {
 }
 
 func (d *domainClient) JavascriptDialogClosed(ctx context.Context) (JavascriptDialogClosedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.javascriptDialogClosed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.javascriptDialogClosed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -910,7 +918,7 @@ func (c *javascriptDialogClosedClient) Recv() (*JavascriptDialogClosedReply, err
 }
 
 func (d *domainClient) JavascriptDialogOpening(ctx context.Context) (JavascriptDialogOpeningClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.javascriptDialogOpening", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.javascriptDialogOpening", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -931,7 +939,7 @@ func (c *javascriptDialogOpeningClient) Recv() (*JavascriptDialogOpeningReply, e
 }
 
 func (d *domainClient) LifecycleEvent(ctx context.Context) (LifecycleEventClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.lifecycleEvent", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.lifecycleEvent", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -952,7 +960,7 @@ func (c *lifecycleEventClient) Recv() (*LifecycleEventReply, error) {
 }
 
 func (d *domainClient) LoadEventFired(ctx context.Context) (LoadEventFiredClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.loadEventFired", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.loadEventFired", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +981,7 @@ func (c *loadEventFiredClient) Recv() (*LoadEventFiredReply, error) {
 }
 
 func (d *domainClient) NavigatedWithinDocument(ctx context.Context) (NavigatedWithinDocumentClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.navigatedWithinDocument", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.navigatedWithinDocument", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -994,7 +1002,7 @@ func (c *navigatedWithinDocumentClient) Recv() (*NavigatedWithinDocumentReply, e
 }
 
 func (d *domainClient) ScreencastFrame(ctx context.Context) (ScreencastFrameClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.screencastFrame", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.screencastFrame", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -1015,7 +1023,7 @@ func (c *screencastFrameClient) Recv() (*ScreencastFrameReply, error) {
 }
 
 func (d *domainClient) ScreencastVisibilityChanged(ctx context.Context) (ScreencastVisibilityChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.screencastVisibilityChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.screencastVisibilityChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -1036,7 +1044,7 @@ func (c *screencastVisibilityChangedClient) Recv() (*ScreencastVisibilityChanged
 }
 
 func (d *domainClient) WindowOpen(ctx context.Context) (WindowOpenClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.windowOpen", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.windowOpen", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -1057,7 +1065,7 @@ func (c *windowOpenClient) Recv() (*WindowOpenReply, error) {
 }
 
 func (d *domainClient) CompilationCacheProduced(ctx context.Context) (CompilationCacheProducedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Page.compilationCacheProduced", d.conn)
+	s, err := rpcc.NewStream(ctx, "Page.compilationCacheProduced", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/profiler/domain.go
+++ b/protocol/profiler/domain.go
@@ -11,16 +11,24 @@ import (
 )
 
 // domainClient is a client for the Profiler domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Profiler domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Profiler domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Profiler method.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Profiler.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "Disable", Err: err}
 	}
@@ -29,7 +37,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 
 // Enable invokes the Profiler method.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Profiler.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "Enable", Err: err}
 	}
@@ -41,7 +49,7 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // collection.
 func (d *domainClient) GetBestEffortCoverage(ctx context.Context) (reply *GetBestEffortCoverageReply, err error) {
 	reply = new(GetBestEffortCoverageReply)
-	err = rpcc.Invoke(ctx, "Profiler.getBestEffortCoverage", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.getBestEffortCoverage", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "GetBestEffortCoverage", Err: err}
 	}
@@ -52,9 +60,9 @@ func (d *domainClient) GetBestEffortCoverage(ctx context.Context) (reply *GetBes
 // sampling interval. Must be called before CPU profiles recording started.
 func (d *domainClient) SetSamplingInterval(ctx context.Context, args *SetSamplingIntervalArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Profiler.setSamplingInterval", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Profiler.setSamplingInterval", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Profiler.setSamplingInterval", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Profiler.setSamplingInterval", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "SetSamplingInterval", Err: err}
@@ -64,7 +72,7 @@ func (d *domainClient) SetSamplingInterval(ctx context.Context, args *SetSamplin
 
 // Start invokes the Profiler method.
 func (d *domainClient) Start(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Profiler.start", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.start", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "Start", Err: err}
 	}
@@ -77,9 +85,9 @@ func (d *domainClient) Start(ctx context.Context) (err error) {
 // resets execution counters.
 func (d *domainClient) StartPreciseCoverage(ctx context.Context, args *StartPreciseCoverageArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Profiler.startPreciseCoverage", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Profiler.startPreciseCoverage", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Profiler.startPreciseCoverage", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Profiler.startPreciseCoverage", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "StartPreciseCoverage", Err: err}
@@ -89,7 +97,7 @@ func (d *domainClient) StartPreciseCoverage(ctx context.Context, args *StartPrec
 
 // StartTypeProfile invokes the Profiler method. Enable type profile.
 func (d *domainClient) StartTypeProfile(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Profiler.startTypeProfile", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.startTypeProfile", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "StartTypeProfile", Err: err}
 	}
@@ -99,7 +107,7 @@ func (d *domainClient) StartTypeProfile(ctx context.Context) (err error) {
 // Stop invokes the Profiler method.
 func (d *domainClient) Stop(ctx context.Context) (reply *StopReply, err error) {
 	reply = new(StopReply)
-	err = rpcc.Invoke(ctx, "Profiler.stop", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.stop", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "Stop", Err: err}
 	}
@@ -110,7 +118,7 @@ func (d *domainClient) Stop(ctx context.Context) (reply *StopReply, err error) {
 // coverage. Disabling releases unnecessary execution count records and allows
 // executing optimized code.
 func (d *domainClient) StopPreciseCoverage(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Profiler.stopPreciseCoverage", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.stopPreciseCoverage", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "StopPreciseCoverage", Err: err}
 	}
@@ -120,7 +128,7 @@ func (d *domainClient) StopPreciseCoverage(ctx context.Context) (err error) {
 // StopTypeProfile invokes the Profiler method. Disable type profile.
 // Disabling releases type profile data collected so far.
 func (d *domainClient) StopTypeProfile(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Profiler.stopTypeProfile", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.stopTypeProfile", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "StopTypeProfile", Err: err}
 	}
@@ -132,7 +140,7 @@ func (d *domainClient) StopTypeProfile(ctx context.Context) (err error) {
 // needs to have started.
 func (d *domainClient) TakePreciseCoverage(ctx context.Context) (reply *TakePreciseCoverageReply, err error) {
 	reply = new(TakePreciseCoverageReply)
-	err = rpcc.Invoke(ctx, "Profiler.takePreciseCoverage", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.takePreciseCoverage", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "TakePreciseCoverage", Err: err}
 	}
@@ -142,7 +150,7 @@ func (d *domainClient) TakePreciseCoverage(ctx context.Context) (reply *TakePrec
 // TakeTypeProfile invokes the Profiler method. Collect type profile.
 func (d *domainClient) TakeTypeProfile(ctx context.Context) (reply *TakeTypeProfileReply, err error) {
 	reply = new(TakeTypeProfileReply)
-	err = rpcc.Invoke(ctx, "Profiler.takeTypeProfile", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Profiler.takeTypeProfile", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Profiler", Op: "TakeTypeProfile", Err: err}
 	}
@@ -150,7 +158,7 @@ func (d *domainClient) TakeTypeProfile(ctx context.Context) (reply *TakeTypeProf
 }
 
 func (d *domainClient) ConsoleProfileFinished(ctx context.Context) (ConsoleProfileFinishedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Profiler.consoleProfileFinished", d.conn)
+	s, err := rpcc.NewStream(ctx, "Profiler.consoleProfileFinished", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +179,7 @@ func (c *consoleProfileFinishedClient) Recv() (*ConsoleProfileFinishedReply, err
 }
 
 func (d *domainClient) ConsoleProfileStarted(ctx context.Context) (ConsoleProfileStartedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Profiler.consoleProfileStarted", d.conn)
+	s, err := rpcc.NewStream(ctx, "Profiler.consoleProfileStarted", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/runtime/domain.go
+++ b/protocol/runtime/domain.go
@@ -23,11 +23,19 @@ import (
 // object reference. Original objects are maintained in memory unless they are
 // either explicitly released or are released along with the other objects in
 // their object group.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Runtime domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
+}
+
+// NewClient returns a client for the Runtime domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
 }
 
 // AwaitPromise invokes the Runtime method. Add handler to promise with given
@@ -35,9 +43,9 @@ func NewClient(conn *rpcc.Conn) *domainClient {
 func (d *domainClient) AwaitPromise(ctx context.Context, args *AwaitPromiseArgs) (reply *AwaitPromiseReply, err error) {
 	reply = new(AwaitPromiseReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.awaitPromise", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.awaitPromise", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.awaitPromise", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.awaitPromise", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "AwaitPromise", Err: err}
@@ -51,9 +59,9 @@ func (d *domainClient) AwaitPromise(ctx context.Context, args *AwaitPromiseArgs)
 func (d *domainClient) CallFunctionOn(ctx context.Context, args *CallFunctionOnArgs) (reply *CallFunctionOnReply, err error) {
 	reply = new(CallFunctionOnReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.callFunctionOn", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.callFunctionOn", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.callFunctionOn", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.callFunctionOn", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "CallFunctionOn", Err: err}
@@ -65,9 +73,9 @@ func (d *domainClient) CallFunctionOn(ctx context.Context, args *CallFunctionOnA
 func (d *domainClient) CompileScript(ctx context.Context, args *CompileScriptArgs) (reply *CompileScriptReply, err error) {
 	reply = new(CompileScriptReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.compileScript", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.compileScript", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.compileScript", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.compileScript", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "CompileScript", Err: err}
@@ -78,7 +86,7 @@ func (d *domainClient) CompileScript(ctx context.Context, args *CompileScriptArg
 // Disable invokes the Runtime method. Disables reporting of execution
 // contexts creation.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Runtime.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "Disable", Err: err}
 	}
@@ -88,7 +96,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // DiscardConsoleEntries invokes the Runtime method. Discards collected
 // exceptions and console API calls.
 func (d *domainClient) DiscardConsoleEntries(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Runtime.discardConsoleEntries", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.discardConsoleEntries", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "DiscardConsoleEntries", Err: err}
 	}
@@ -100,7 +108,7 @@ func (d *domainClient) DiscardConsoleEntries(ctx context.Context) (err error) {
 // gets enabled the event will be sent immediately for each existing execution
 // context.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Runtime.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "Enable", Err: err}
 	}
@@ -111,9 +119,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 func (d *domainClient) Evaluate(ctx context.Context, args *EvaluateArgs) (reply *EvaluateReply, err error) {
 	reply = new(EvaluateReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.evaluate", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.evaluate", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.evaluate", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.evaluate", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "Evaluate", Err: err}
@@ -124,7 +132,7 @@ func (d *domainClient) Evaluate(ctx context.Context, args *EvaluateArgs) (reply 
 // GetIsolateID invokes the Runtime method. Returns the isolate id.
 func (d *domainClient) GetIsolateID(ctx context.Context) (reply *GetIsolateIDReply, err error) {
 	reply = new(GetIsolateIDReply)
-	err = rpcc.Invoke(ctx, "Runtime.getIsolateId", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.getIsolateId", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "GetIsolateID", Err: err}
 	}
@@ -136,7 +144,7 @@ func (d *domainClient) GetIsolateID(ctx context.Context) (reply *GetIsolateIDRep
 // particular Runtime.
 func (d *domainClient) GetHeapUsage(ctx context.Context) (reply *GetHeapUsageReply, err error) {
 	reply = new(GetHeapUsageReply)
-	err = rpcc.Invoke(ctx, "Runtime.getHeapUsage", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.getHeapUsage", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "GetHeapUsage", Err: err}
 	}
@@ -148,9 +156,9 @@ func (d *domainClient) GetHeapUsage(ctx context.Context) (reply *GetHeapUsageRep
 func (d *domainClient) GetProperties(ctx context.Context, args *GetPropertiesArgs) (reply *GetPropertiesReply, err error) {
 	reply = new(GetPropertiesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.getProperties", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.getProperties", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.getProperties", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.getProperties", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "GetProperties", Err: err}
@@ -163,9 +171,9 @@ func (d *domainClient) GetProperties(ctx context.Context, args *GetPropertiesArg
 func (d *domainClient) GlobalLexicalScopeNames(ctx context.Context, args *GlobalLexicalScopeNamesArgs) (reply *GlobalLexicalScopeNamesReply, err error) {
 	reply = new(GlobalLexicalScopeNamesReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.globalLexicalScopeNames", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.globalLexicalScopeNames", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.globalLexicalScopeNames", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.globalLexicalScopeNames", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "GlobalLexicalScopeNames", Err: err}
@@ -177,9 +185,9 @@ func (d *domainClient) GlobalLexicalScopeNames(ctx context.Context, args *Global
 func (d *domainClient) QueryObjects(ctx context.Context, args *QueryObjectsArgs) (reply *QueryObjectsReply, err error) {
 	reply = new(QueryObjectsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.queryObjects", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.queryObjects", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.queryObjects", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.queryObjects", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "QueryObjects", Err: err}
@@ -191,9 +199,9 @@ func (d *domainClient) QueryObjects(ctx context.Context, args *QueryObjectsArgs)
 // id.
 func (d *domainClient) ReleaseObject(ctx context.Context, args *ReleaseObjectArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.releaseObject", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.releaseObject", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.releaseObject", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.releaseObject", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "ReleaseObject", Err: err}
@@ -205,9 +213,9 @@ func (d *domainClient) ReleaseObject(ctx context.Context, args *ReleaseObjectArg
 // that belong to a given group.
 func (d *domainClient) ReleaseObjectGroup(ctx context.Context, args *ReleaseObjectGroupArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.releaseObjectGroup", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.releaseObjectGroup", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.releaseObjectGroup", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.releaseObjectGroup", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "ReleaseObjectGroup", Err: err}
@@ -218,7 +226,7 @@ func (d *domainClient) ReleaseObjectGroup(ctx context.Context, args *ReleaseObje
 // RunIfWaitingForDebugger invokes the Runtime method. Tells inspected
 // instance to run if it was waiting for debugger to attach.
 func (d *domainClient) RunIfWaitingForDebugger(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Runtime.runIfWaitingForDebugger", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.runIfWaitingForDebugger", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "RunIfWaitingForDebugger", Err: err}
 	}
@@ -230,9 +238,9 @@ func (d *domainClient) RunIfWaitingForDebugger(ctx context.Context) (err error) 
 func (d *domainClient) RunScript(ctx context.Context, args *RunScriptArgs) (reply *RunScriptReply, err error) {
 	reply = new(RunScriptReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.runScript", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.runScript", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.runScript", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.runScript", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "RunScript", Err: err}
@@ -243,9 +251,9 @@ func (d *domainClient) RunScript(ctx context.Context, args *RunScriptArgs) (repl
 // SetCustomObjectFormatterEnabled invokes the Runtime method.
 func (d *domainClient) SetCustomObjectFormatterEnabled(ctx context.Context, args *SetCustomObjectFormatterEnabledArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.setCustomObjectFormatterEnabled", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.setCustomObjectFormatterEnabled", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.setCustomObjectFormatterEnabled", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.setCustomObjectFormatterEnabled", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "SetCustomObjectFormatterEnabled", Err: err}
@@ -256,9 +264,9 @@ func (d *domainClient) SetCustomObjectFormatterEnabled(ctx context.Context, args
 // SetMaxCallStackSizeToCapture invokes the Runtime method.
 func (d *domainClient) SetMaxCallStackSizeToCapture(ctx context.Context, args *SetMaxCallStackSizeToCaptureArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.setMaxCallStackSizeToCapture", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.setMaxCallStackSizeToCapture", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.setMaxCallStackSizeToCapture", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.setMaxCallStackSizeToCapture", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "SetMaxCallStackSizeToCapture", Err: err}
@@ -270,7 +278,7 @@ func (d *domainClient) SetMaxCallStackSizeToCapture(ctx context.Context, args *S
 // JavaScript execution. Will cancel the termination when the outer-most script
 // execution ends.
 func (d *domainClient) TerminateExecution(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Runtime.terminateExecution", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Runtime.terminateExecution", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "TerminateExecution", Err: err}
 	}
@@ -287,9 +295,9 @@ func (d *domainClient) TerminateExecution(ctx context.Context) (err error) {
 // notification.
 func (d *domainClient) AddBinding(ctx context.Context, args *AddBindingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.addBinding", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.addBinding", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.addBinding", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.addBinding", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "AddBinding", Err: err}
@@ -302,9 +310,9 @@ func (d *domainClient) AddBinding(ctx context.Context, args *AddBindingArgs) (er
 // from Runtime.bindingCalled notifications.
 func (d *domainClient) RemoveBinding(ctx context.Context, args *RemoveBindingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Runtime.removeBinding", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.removeBinding", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Runtime.removeBinding", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Runtime.removeBinding", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Runtime", Op: "RemoveBinding", Err: err}
@@ -313,7 +321,7 @@ func (d *domainClient) RemoveBinding(ctx context.Context, args *RemoveBindingArg
 }
 
 func (d *domainClient) BindingCalled(ctx context.Context) (BindingCalledClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.bindingCalled", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.bindingCalled", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +342,7 @@ func (c *bindingCalledClient) Recv() (*BindingCalledReply, error) {
 }
 
 func (d *domainClient) ConsoleAPICalled(ctx context.Context) (ConsoleAPICalledClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.consoleAPICalled", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.consoleAPICalled", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +363,7 @@ func (c *consoleAPICalledClient) Recv() (*ConsoleAPICalledReply, error) {
 }
 
 func (d *domainClient) ExceptionRevoked(ctx context.Context) (ExceptionRevokedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.exceptionRevoked", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.exceptionRevoked", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +384,7 @@ func (c *exceptionRevokedClient) Recv() (*ExceptionRevokedReply, error) {
 }
 
 func (d *domainClient) ExceptionThrown(ctx context.Context) (ExceptionThrownClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.exceptionThrown", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.exceptionThrown", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +405,7 @@ func (c *exceptionThrownClient) Recv() (*ExceptionThrownReply, error) {
 }
 
 func (d *domainClient) ExecutionContextCreated(ctx context.Context) (ExecutionContextCreatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.executionContextCreated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.executionContextCreated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +426,7 @@ func (c *executionContextCreatedClient) Recv() (*ExecutionContextCreatedReply, e
 }
 
 func (d *domainClient) ExecutionContextDestroyed(ctx context.Context) (ExecutionContextDestroyedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.executionContextDestroyed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.executionContextDestroyed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +447,7 @@ func (c *executionContextDestroyedClient) Recv() (*ExecutionContextDestroyedRepl
 }
 
 func (d *domainClient) ExecutionContextsCleared(ctx context.Context) (ExecutionContextsClearedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.executionContextsCleared", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.executionContextsCleared", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +468,7 @@ func (c *executionContextsClearedClient) Recv() (*ExecutionContextsClearedReply,
 }
 
 func (d *domainClient) InspectRequested(ctx context.Context) (InspectRequestedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Runtime.inspectRequested", d.conn)
+	s, err := rpcc.NewStream(ctx, "Runtime.inspectRequested", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/schema/domain.go
+++ b/protocol/schema/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the Schema domain. This domain is deprecated.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Schema domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Schema domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // GetDomains invokes the Schema method. Returns supported domains.
 func (d *domainClient) GetDomains(ctx context.Context) (reply *GetDomainsReply, err error) {
 	reply = new(GetDomainsReply)
-	err = rpcc.Invoke(ctx, "Schema.getDomains", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Schema.getDomains", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Schema", Op: "GetDomains", Err: err}
 	}

--- a/protocol/security/domain.go
+++ b/protocol/security/domain.go
@@ -11,17 +11,25 @@ import (
 )
 
 // domainClient is a client for the Security domain. Security
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Security domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Security domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Disable invokes the Security method. Disables tracking security state
 // changes.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Security.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Security.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Security", Op: "Disable", Err: err}
 	}
@@ -31,7 +39,7 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // Enable invokes the Security method. Enables tracking security state
 // changes.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "Security.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Security.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Security", Op: "Enable", Err: err}
 	}
@@ -42,9 +50,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // whether all certificate errors should be ignored.
 func (d *domainClient) SetIgnoreCertificateErrors(ctx context.Context, args *SetIgnoreCertificateErrorsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Security.setIgnoreCertificateErrors", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Security.setIgnoreCertificateErrors", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Security.setIgnoreCertificateErrors", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Security.setIgnoreCertificateErrors", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Security", Op: "SetIgnoreCertificateErrors", Err: err}
@@ -56,9 +64,9 @@ func (d *domainClient) SetIgnoreCertificateErrors(ctx context.Context, args *Set
 // error that fired a certificateError event.
 func (d *domainClient) HandleCertificateError(ctx context.Context, args *HandleCertificateErrorArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Security.handleCertificateError", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Security.handleCertificateError", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Security.handleCertificateError", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Security.handleCertificateError", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Security", Op: "HandleCertificateError", Err: err}
@@ -72,9 +80,9 @@ func (d *domainClient) HandleCertificateError(ctx context.Context, args *HandleC
 // `handleCertificateError` commands.
 func (d *domainClient) SetOverrideCertificateErrors(ctx context.Context, args *SetOverrideCertificateErrorsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Security.setOverrideCertificateErrors", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Security.setOverrideCertificateErrors", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Security.setOverrideCertificateErrors", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Security.setOverrideCertificateErrors", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Security", Op: "SetOverrideCertificateErrors", Err: err}
@@ -83,7 +91,7 @@ func (d *domainClient) SetOverrideCertificateErrors(ctx context.Context, args *S
 }
 
 func (d *domainClient) CertificateError(ctx context.Context) (CertificateErrorClient, error) {
-	s, err := rpcc.NewStream(ctx, "Security.certificateError", d.conn)
+	s, err := rpcc.NewStream(ctx, "Security.certificateError", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +112,7 @@ func (c *certificateErrorClient) Recv() (*CertificateErrorReply, error) {
 }
 
 func (d *domainClient) SecurityStateChanged(ctx context.Context) (StateChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Security.securityStateChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "Security.securityStateChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/serviceworker/domain.go
+++ b/protocol/serviceworker/domain.go
@@ -11,19 +11,27 @@ import (
 )
 
 // domainClient is a client for the ServiceWorker domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the ServiceWorker domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the ServiceWorker domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // DeliverPushMessage invokes the ServiceWorker method.
 func (d *domainClient) DeliverPushMessage(ctx context.Context, args *DeliverPushMessageArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.deliverPushMessage", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.deliverPushMessage", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.deliverPushMessage", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.deliverPushMessage", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "DeliverPushMessage", Err: err}
@@ -33,7 +41,7 @@ func (d *domainClient) DeliverPushMessage(ctx context.Context, args *DeliverPush
 
 // Disable invokes the ServiceWorker method.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "ServiceWorker.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "ServiceWorker.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "Disable", Err: err}
 	}
@@ -43,9 +51,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 // DispatchSyncEvent invokes the ServiceWorker method.
 func (d *domainClient) DispatchSyncEvent(ctx context.Context, args *DispatchSyncEventArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.dispatchSyncEvent", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.dispatchSyncEvent", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.dispatchSyncEvent", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.dispatchSyncEvent", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "DispatchSyncEvent", Err: err}
@@ -55,7 +63,7 @@ func (d *domainClient) DispatchSyncEvent(ctx context.Context, args *DispatchSync
 
 // Enable invokes the ServiceWorker method.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "ServiceWorker.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "ServiceWorker.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "Enable", Err: err}
 	}
@@ -65,9 +73,9 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 // InspectWorker invokes the ServiceWorker method.
 func (d *domainClient) InspectWorker(ctx context.Context, args *InspectWorkerArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.inspectWorker", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.inspectWorker", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.inspectWorker", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.inspectWorker", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "InspectWorker", Err: err}
@@ -78,9 +86,9 @@ func (d *domainClient) InspectWorker(ctx context.Context, args *InspectWorkerArg
 // SetForceUpdateOnPageLoad invokes the ServiceWorker method.
 func (d *domainClient) SetForceUpdateOnPageLoad(ctx context.Context, args *SetForceUpdateOnPageLoadArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.setForceUpdateOnPageLoad", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.setForceUpdateOnPageLoad", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.setForceUpdateOnPageLoad", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.setForceUpdateOnPageLoad", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "SetForceUpdateOnPageLoad", Err: err}
@@ -91,9 +99,9 @@ func (d *domainClient) SetForceUpdateOnPageLoad(ctx context.Context, args *SetFo
 // SkipWaiting invokes the ServiceWorker method.
 func (d *domainClient) SkipWaiting(ctx context.Context, args *SkipWaitingArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.skipWaiting", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.skipWaiting", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.skipWaiting", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.skipWaiting", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "SkipWaiting", Err: err}
@@ -104,9 +112,9 @@ func (d *domainClient) SkipWaiting(ctx context.Context, args *SkipWaitingArgs) (
 // StartWorker invokes the ServiceWorker method.
 func (d *domainClient) StartWorker(ctx context.Context, args *StartWorkerArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.startWorker", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.startWorker", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.startWorker", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.startWorker", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "StartWorker", Err: err}
@@ -116,7 +124,7 @@ func (d *domainClient) StartWorker(ctx context.Context, args *StartWorkerArgs) (
 
 // StopAllWorkers invokes the ServiceWorker method.
 func (d *domainClient) StopAllWorkers(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "ServiceWorker.stopAllWorkers", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "ServiceWorker.stopAllWorkers", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "StopAllWorkers", Err: err}
 	}
@@ -126,9 +134,9 @@ func (d *domainClient) StopAllWorkers(ctx context.Context) (err error) {
 // StopWorker invokes the ServiceWorker method.
 func (d *domainClient) StopWorker(ctx context.Context, args *StopWorkerArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.stopWorker", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.stopWorker", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.stopWorker", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.stopWorker", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "StopWorker", Err: err}
@@ -139,9 +147,9 @@ func (d *domainClient) StopWorker(ctx context.Context, args *StopWorkerArgs) (er
 // Unregister invokes the ServiceWorker method.
 func (d *domainClient) Unregister(ctx context.Context, args *UnregisterArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.unregister", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.unregister", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.unregister", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.unregister", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "Unregister", Err: err}
@@ -152,9 +160,9 @@ func (d *domainClient) Unregister(ctx context.Context, args *UnregisterArgs) (er
 // UpdateRegistration invokes the ServiceWorker method.
 func (d *domainClient) UpdateRegistration(ctx context.Context, args *UpdateRegistrationArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "ServiceWorker.updateRegistration", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.updateRegistration", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "ServiceWorker.updateRegistration", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "ServiceWorker.updateRegistration", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "ServiceWorker", Op: "UpdateRegistration", Err: err}
@@ -163,7 +171,7 @@ func (d *domainClient) UpdateRegistration(ctx context.Context, args *UpdateRegis
 }
 
 func (d *domainClient) WorkerErrorReported(ctx context.Context) (WorkerErrorReportedClient, error) {
-	s, err := rpcc.NewStream(ctx, "ServiceWorker.workerErrorReported", d.conn)
+	s, err := rpcc.NewStream(ctx, "ServiceWorker.workerErrorReported", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +192,7 @@ func (c *workerErrorReportedClient) Recv() (*WorkerErrorReportedReply, error) {
 }
 
 func (d *domainClient) WorkerRegistrationUpdated(ctx context.Context) (WorkerRegistrationUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "ServiceWorker.workerRegistrationUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "ServiceWorker.workerRegistrationUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +213,7 @@ func (c *workerRegistrationUpdatedClient) Recv() (*WorkerRegistrationUpdatedRepl
 }
 
 func (d *domainClient) WorkerVersionUpdated(ctx context.Context) (WorkerVersionUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "ServiceWorker.workerVersionUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "ServiceWorker.workerVersionUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/storage/domain.go
+++ b/protocol/storage/domain.go
@@ -11,19 +11,27 @@ import (
 )
 
 // domainClient is a client for the Storage domain.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Storage domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Storage domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // ClearDataForOrigin invokes the Storage method. Clears storage for origin.
 func (d *domainClient) ClearDataForOrigin(ctx context.Context, args *ClearDataForOriginArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Storage.clearDataForOrigin", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.clearDataForOrigin", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Storage.clearDataForOrigin", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.clearDataForOrigin", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Storage", Op: "ClearDataForOrigin", Err: err}
@@ -36,9 +44,9 @@ func (d *domainClient) ClearDataForOrigin(ctx context.Context, args *ClearDataFo
 func (d *domainClient) GetUsageAndQuota(ctx context.Context, args *GetUsageAndQuotaArgs) (reply *GetUsageAndQuotaReply, err error) {
 	reply = new(GetUsageAndQuotaReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Storage.getUsageAndQuota", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.getUsageAndQuota", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Storage.getUsageAndQuota", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.getUsageAndQuota", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Storage", Op: "GetUsageAndQuota", Err: err}
@@ -50,9 +58,9 @@ func (d *domainClient) GetUsageAndQuota(ctx context.Context, args *GetUsageAndQu
 // be notified when an update occurs to its cache storage list.
 func (d *domainClient) TrackCacheStorageForOrigin(ctx context.Context, args *TrackCacheStorageForOriginArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Storage.trackCacheStorageForOrigin", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.trackCacheStorageForOrigin", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Storage.trackCacheStorageForOrigin", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.trackCacheStorageForOrigin", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Storage", Op: "TrackCacheStorageForOrigin", Err: err}
@@ -64,9 +72,9 @@ func (d *domainClient) TrackCacheStorageForOrigin(ctx context.Context, args *Tra
 // notified when an update occurs to its IndexedDB.
 func (d *domainClient) TrackIndexedDBForOrigin(ctx context.Context, args *TrackIndexedDBForOriginArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Storage.trackIndexedDBForOrigin", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.trackIndexedDBForOrigin", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Storage.trackIndexedDBForOrigin", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.trackIndexedDBForOrigin", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Storage", Op: "TrackIndexedDBForOrigin", Err: err}
@@ -78,9 +86,9 @@ func (d *domainClient) TrackIndexedDBForOrigin(ctx context.Context, args *TrackI
 // from receiving notifications for cache storage.
 func (d *domainClient) UntrackCacheStorageForOrigin(ctx context.Context, args *UntrackCacheStorageForOriginArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Storage.untrackCacheStorageForOrigin", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.untrackCacheStorageForOrigin", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Storage.untrackCacheStorageForOrigin", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.untrackCacheStorageForOrigin", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Storage", Op: "UntrackCacheStorageForOrigin", Err: err}
@@ -92,9 +100,9 @@ func (d *domainClient) UntrackCacheStorageForOrigin(ctx context.Context, args *U
 // from receiving notifications for IndexedDB.
 func (d *domainClient) UntrackIndexedDBForOrigin(ctx context.Context, args *UntrackIndexedDBForOriginArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Storage.untrackIndexedDBForOrigin", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.untrackIndexedDBForOrigin", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Storage.untrackIndexedDBForOrigin", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Storage.untrackIndexedDBForOrigin", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Storage", Op: "UntrackIndexedDBForOrigin", Err: err}
@@ -103,7 +111,7 @@ func (d *domainClient) UntrackIndexedDBForOrigin(ctx context.Context, args *Untr
 }
 
 func (d *domainClient) CacheStorageContentUpdated(ctx context.Context) (CacheStorageContentUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Storage.cacheStorageContentUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Storage.cacheStorageContentUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +132,7 @@ func (c *cacheStorageContentUpdatedClient) Recv() (*CacheStorageContentUpdatedRe
 }
 
 func (d *domainClient) CacheStorageListUpdated(ctx context.Context) (CacheStorageListUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Storage.cacheStorageListUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Storage.cacheStorageListUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +153,7 @@ func (c *cacheStorageListUpdatedClient) Recv() (*CacheStorageListUpdatedReply, e
 }
 
 func (d *domainClient) IndexedDBContentUpdated(ctx context.Context) (IndexedDBContentUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Storage.indexedDBContentUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Storage.indexedDBContentUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +174,7 @@ func (c *indexedDBContentUpdatedClient) Recv() (*IndexedDBContentUpdatedReply, e
 }
 
 func (d *domainClient) IndexedDBListUpdated(ctx context.Context) (IndexedDBListUpdatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Storage.indexedDBListUpdated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Storage.indexedDBListUpdated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/systeminfo/domain.go
+++ b/protocol/systeminfo/domain.go
@@ -13,18 +13,26 @@ import (
 
 // domainClient is a client for the SystemInfo domain. The SystemInfo domain
 // defines methods and events for querying low-level system information.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the SystemInfo domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the SystemInfo domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // GetInfo invokes the SystemInfo method. Returns information about the
 // system.
 func (d *domainClient) GetInfo(ctx context.Context) (reply *GetInfoReply, err error) {
 	reply = new(GetInfoReply)
-	err = rpcc.Invoke(ctx, "SystemInfo.getInfo", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "SystemInfo.getInfo", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "SystemInfo", Op: "GetInfo", Err: err}
 	}
@@ -35,7 +43,7 @@ func (d *domainClient) GetInfo(ctx context.Context) (reply *GetInfoReply, err er
 // running processes.
 func (d *domainClient) GetProcessInfo(ctx context.Context) (reply *GetProcessInfoReply, err error) {
 	reply = new(GetProcessInfoReply)
-	err = rpcc.Invoke(ctx, "SystemInfo.getProcessInfo", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "SystemInfo.getProcessInfo", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "SystemInfo", Op: "GetProcessInfo", Err: err}
 	}

--- a/protocol/target/domain.go
+++ b/protocol/target/domain.go
@@ -13,19 +13,27 @@ import (
 
 // domainClient is a client for the Target domain. Supports additional targets
 // discovery and allows to attach to them.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Target domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Target domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // ActivateTarget invokes the Target method. Activates (focuses) the target.
 func (d *domainClient) ActivateTarget(ctx context.Context, args *ActivateTargetArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.activateTarget", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.activateTarget", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.activateTarget", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.activateTarget", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "ActivateTarget", Err: err}
@@ -38,9 +46,9 @@ func (d *domainClient) ActivateTarget(ctx context.Context, args *ActivateTargetA
 func (d *domainClient) AttachToTarget(ctx context.Context, args *AttachToTargetArgs) (reply *AttachToTargetReply, err error) {
 	reply = new(AttachToTargetReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.attachToTarget", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.attachToTarget", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.attachToTarget", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.attachToTarget", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "AttachToTarget", Err: err}
@@ -52,7 +60,7 @@ func (d *domainClient) AttachToTarget(ctx context.Context, args *AttachToTargetA
 // target, only uses flat sessionId mode.
 func (d *domainClient) AttachToBrowserTarget(ctx context.Context) (reply *AttachToBrowserTargetReply, err error) {
 	reply = new(AttachToBrowserTargetReply)
-	err = rpcc.Invoke(ctx, "Target.attachToBrowserTarget", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Target.attachToBrowserTarget", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "AttachToBrowserTarget", Err: err}
 	}
@@ -64,9 +72,9 @@ func (d *domainClient) AttachToBrowserTarget(ctx context.Context) (reply *Attach
 func (d *domainClient) CloseTarget(ctx context.Context, args *CloseTargetArgs) (reply *CloseTargetReply, err error) {
 	reply = new(CloseTargetReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.closeTarget", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.closeTarget", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.closeTarget", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.closeTarget", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "CloseTarget", Err: err}
@@ -86,9 +94,9 @@ func (d *domainClient) CloseTarget(ctx context.Context, args *CloseTargetArgs) (
 // notifications and command responses.
 func (d *domainClient) ExposeDevToolsProtocol(ctx context.Context, args *ExposeDevToolsProtocolArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.exposeDevToolsProtocol", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.exposeDevToolsProtocol", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.exposeDevToolsProtocol", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.exposeDevToolsProtocol", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "ExposeDevToolsProtocol", Err: err}
@@ -101,7 +109,7 @@ func (d *domainClient) ExposeDevToolsProtocol(ctx context.Context, args *ExposeD
 // one.
 func (d *domainClient) CreateBrowserContext(ctx context.Context) (reply *CreateBrowserContextReply, err error) {
 	reply = new(CreateBrowserContextReply)
-	err = rpcc.Invoke(ctx, "Target.createBrowserContext", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Target.createBrowserContext", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "CreateBrowserContext", Err: err}
 	}
@@ -112,7 +120,7 @@ func (d *domainClient) CreateBrowserContext(ctx context.Context) (reply *CreateB
 // created with `Target.createBrowserContext` method.
 func (d *domainClient) GetBrowserContexts(ctx context.Context) (reply *GetBrowserContextsReply, err error) {
 	reply = new(GetBrowserContextsReply)
-	err = rpcc.Invoke(ctx, "Target.getBrowserContexts", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Target.getBrowserContexts", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "GetBrowserContexts", Err: err}
 	}
@@ -123,9 +131,9 @@ func (d *domainClient) GetBrowserContexts(ctx context.Context) (reply *GetBrowse
 func (d *domainClient) CreateTarget(ctx context.Context, args *CreateTargetArgs) (reply *CreateTargetReply, err error) {
 	reply = new(CreateTargetReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.createTarget", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.createTarget", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.createTarget", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.createTarget", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "CreateTarget", Err: err}
@@ -136,9 +144,9 @@ func (d *domainClient) CreateTarget(ctx context.Context, args *CreateTargetArgs)
 // DetachFromTarget invokes the Target method. Detaches session with given id.
 func (d *domainClient) DetachFromTarget(ctx context.Context, args *DetachFromTargetArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.detachFromTarget", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.detachFromTarget", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.detachFromTarget", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.detachFromTarget", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "DetachFromTarget", Err: err}
@@ -151,9 +159,9 @@ func (d *domainClient) DetachFromTarget(ctx context.Context, args *DetachFromTar
 // hooks.
 func (d *domainClient) DisposeBrowserContext(ctx context.Context, args *DisposeBrowserContextArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.disposeBrowserContext", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.disposeBrowserContext", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.disposeBrowserContext", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.disposeBrowserContext", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "DisposeBrowserContext", Err: err}
@@ -166,9 +174,9 @@ func (d *domainClient) DisposeBrowserContext(ctx context.Context, args *DisposeB
 func (d *domainClient) GetTargetInfo(ctx context.Context, args *GetTargetInfoArgs) (reply *GetTargetInfoReply, err error) {
 	reply = new(GetTargetInfoReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.getTargetInfo", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.getTargetInfo", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.getTargetInfo", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.getTargetInfo", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "GetTargetInfo", Err: err}
@@ -180,7 +188,7 @@ func (d *domainClient) GetTargetInfo(ctx context.Context, args *GetTargetInfoArg
 // targets.
 func (d *domainClient) GetTargets(ctx context.Context) (reply *GetTargetsReply, err error) {
 	reply = new(GetTargetsReply)
-	err = rpcc.Invoke(ctx, "Target.getTargets", nil, reply, d.conn)
+	err = rpcc.InvokeRPC(ctx, "Target.getTargets", d.sessionID, nil, reply, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "GetTargets", Err: err}
 	}
@@ -191,9 +199,9 @@ func (d *domainClient) GetTargets(ctx context.Context) (reply *GetTargetsReply, 
 // session with given id.
 func (d *domainClient) SendMessageToTarget(ctx context.Context, args *SendMessageToTargetArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.sendMessageToTarget", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.sendMessageToTarget", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.sendMessageToTarget", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.sendMessageToTarget", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "SendMessageToTarget", Err: err}
@@ -207,9 +215,9 @@ func (d *domainClient) SendMessageToTarget(ctx context.Context, args *SendMessag
 // off, automatically detaches from all currently attached targets.
 func (d *domainClient) SetAutoAttach(ctx context.Context, args *SetAutoAttachArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.setAutoAttach", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.setAutoAttach", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.setAutoAttach", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.setAutoAttach", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "SetAutoAttach", Err: err}
@@ -222,9 +230,9 @@ func (d *domainClient) SetAutoAttach(ctx context.Context, args *SetAutoAttachArg
 // `targetCreated/targetInfoChanged/targetDestroyed` events.
 func (d *domainClient) SetDiscoverTargets(ctx context.Context, args *SetDiscoverTargetsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.setDiscoverTargets", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.setDiscoverTargets", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.setDiscoverTargets", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.setDiscoverTargets", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "SetDiscoverTargets", Err: err}
@@ -236,9 +244,9 @@ func (d *domainClient) SetDiscoverTargets(ctx context.Context, args *SetDiscover
 // the specified locations, when `setDiscoverTargets` was set to `true`.
 func (d *domainClient) SetRemoteLocations(ctx context.Context, args *SetRemoteLocationsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Target.setRemoteLocations", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.setRemoteLocations", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Target.setRemoteLocations", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Target.setRemoteLocations", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Target", Op: "SetRemoteLocations", Err: err}
@@ -247,7 +255,7 @@ func (d *domainClient) SetRemoteLocations(ctx context.Context, args *SetRemoteLo
 }
 
 func (d *domainClient) AttachedToTarget(ctx context.Context) (AttachedToTargetClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.attachedToTarget", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.attachedToTarget", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +276,7 @@ func (c *attachedToTargetClient) Recv() (*AttachedToTargetReply, error) {
 }
 
 func (d *domainClient) DetachedFromTarget(ctx context.Context) (DetachedFromTargetClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.detachedFromTarget", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.detachedFromTarget", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +297,7 @@ func (c *detachedFromTargetClient) Recv() (*DetachedFromTargetReply, error) {
 }
 
 func (d *domainClient) ReceivedMessageFromTarget(ctx context.Context) (ReceivedMessageFromTargetClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.receivedMessageFromTarget", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.receivedMessageFromTarget", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +318,7 @@ func (c *receivedMessageFromTargetClient) Recv() (*ReceivedMessageFromTargetRepl
 }
 
 func (d *domainClient) TargetCreated(ctx context.Context) (CreatedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.targetCreated", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.targetCreated", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +339,7 @@ func (c *createdClient) Recv() (*CreatedReply, error) {
 }
 
 func (d *domainClient) TargetDestroyed(ctx context.Context) (DestroyedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.targetDestroyed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.targetDestroyed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +360,7 @@ func (c *destroyedClient) Recv() (*DestroyedReply, error) {
 }
 
 func (d *domainClient) TargetCrashed(ctx context.Context) (CrashedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.targetCrashed", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.targetCrashed", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +381,7 @@ func (c *crashedClient) Recv() (*CrashedReply, error) {
 }
 
 func (d *domainClient) TargetInfoChanged(ctx context.Context) (InfoChangedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Target.targetInfoChanged", d.conn)
+	s, err := rpcc.NewStream(ctx, "Target.targetInfoChanged", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/tethering/domain.go
+++ b/protocol/tethering/domain.go
@@ -13,19 +13,27 @@ import (
 
 // domainClient is a client for the Tethering domain. The Tethering domain
 // defines methods and events for browser port binding.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the Tethering domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the Tethering domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Bind invokes the Tethering method. Request browser port binding.
 func (d *domainClient) Bind(ctx context.Context, args *BindArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Tethering.bind", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Tethering.bind", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Tethering.bind", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Tethering.bind", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Tethering", Op: "Bind", Err: err}
@@ -36,9 +44,9 @@ func (d *domainClient) Bind(ctx context.Context, args *BindArgs) (err error) {
 // Unbind invokes the Tethering method. Request browser port unbinding.
 func (d *domainClient) Unbind(ctx context.Context, args *UnbindArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "Tethering.unbind", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Tethering.unbind", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "Tethering.unbind", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "Tethering.unbind", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "Tethering", Op: "Unbind", Err: err}
@@ -47,7 +55,7 @@ func (d *domainClient) Unbind(ctx context.Context, args *UnbindArgs) (err error)
 }
 
 func (d *domainClient) Accepted(ctx context.Context) (AcceptedClient, error) {
-	s, err := rpcc.NewStream(ctx, "Tethering.accepted", d.conn)
+	s, err := rpcc.NewStream(ctx, "Tethering.accepted", d.sessionID, d.conn)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/webauthn/domain.go
+++ b/protocol/webauthn/domain.go
@@ -13,17 +13,25 @@ import (
 
 // domainClient is a client for the WebAuthn domain. This domain allows
 // configuring virtual authenticators to test the WebAuthn API.
-type domainClient struct{ conn *rpcc.Conn }
+type domainClient struct {
+	conn      *rpcc.Conn
+	sessionID string
+}
 
 // NewClient returns a client for the WebAuthn domain with the connection set to conn.
 func NewClient(conn *rpcc.Conn) *domainClient {
 	return &domainClient{conn: conn}
 }
 
+// NewClient returns a client for the WebAuthn domain with the connection set to conn.
+func NewSessionClient(conn *rpcc.Conn, sessionID string) *domainClient {
+	return &domainClient{conn: conn, sessionID: sessionID}
+}
+
 // Enable invokes the WebAuthn method. Enable the WebAuthn domain and start
 // intercepting credential storage and retrieval with a virtual authenticator.
 func (d *domainClient) Enable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "WebAuthn.enable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "WebAuthn.enable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "Enable", Err: err}
 	}
@@ -32,7 +40,7 @@ func (d *domainClient) Enable(ctx context.Context) (err error) {
 
 // Disable invokes the WebAuthn method. Disable the WebAuthn domain.
 func (d *domainClient) Disable(ctx context.Context) (err error) {
-	err = rpcc.Invoke(ctx, "WebAuthn.disable", nil, nil, d.conn)
+	err = rpcc.InvokeRPC(ctx, "WebAuthn.disable", d.sessionID, nil, nil, d.conn)
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "Disable", Err: err}
 	}
@@ -44,9 +52,9 @@ func (d *domainClient) Disable(ctx context.Context) (err error) {
 func (d *domainClient) AddVirtualAuthenticator(ctx context.Context, args *AddVirtualAuthenticatorArgs) (reply *AddVirtualAuthenticatorReply, err error) {
 	reply = new(AddVirtualAuthenticatorReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "WebAuthn.addVirtualAuthenticator", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.addVirtualAuthenticator", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "WebAuthn.addVirtualAuthenticator", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.addVirtualAuthenticator", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "AddVirtualAuthenticator", Err: err}
@@ -58,9 +66,9 @@ func (d *domainClient) AddVirtualAuthenticator(ctx context.Context, args *AddVir
 // authenticator.
 func (d *domainClient) RemoveVirtualAuthenticator(ctx context.Context, args *RemoveVirtualAuthenticatorArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "WebAuthn.removeVirtualAuthenticator", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.removeVirtualAuthenticator", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "WebAuthn.removeVirtualAuthenticator", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.removeVirtualAuthenticator", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "RemoveVirtualAuthenticator", Err: err}
@@ -72,9 +80,9 @@ func (d *domainClient) RemoveVirtualAuthenticator(ctx context.Context, args *Rem
 // specified authenticator.
 func (d *domainClient) AddCredential(ctx context.Context, args *AddCredentialArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "WebAuthn.addCredential", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.addCredential", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "WebAuthn.addCredential", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.addCredential", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "AddCredential", Err: err}
@@ -87,9 +95,9 @@ func (d *domainClient) AddCredential(ctx context.Context, args *AddCredentialArg
 func (d *domainClient) GetCredentials(ctx context.Context, args *GetCredentialsArgs) (reply *GetCredentialsReply, err error) {
 	reply = new(GetCredentialsReply)
 	if args != nil {
-		err = rpcc.Invoke(ctx, "WebAuthn.getCredentials", args, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.getCredentials", d.sessionID, args, reply, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "WebAuthn.getCredentials", nil, reply, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.getCredentials", d.sessionID, nil, reply, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "GetCredentials", Err: err}
@@ -101,9 +109,9 @@ func (d *domainClient) GetCredentials(ctx context.Context, args *GetCredentialsA
 // from the specified device.
 func (d *domainClient) ClearCredentials(ctx context.Context, args *ClearCredentialsArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "WebAuthn.clearCredentials", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.clearCredentials", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "WebAuthn.clearCredentials", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.clearCredentials", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "ClearCredentials", Err: err}
@@ -115,9 +123,9 @@ func (d *domainClient) ClearCredentials(ctx context.Context, args *ClearCredenti
 // succeeds or fails for an authenticator. The default is true.
 func (d *domainClient) SetUserVerified(ctx context.Context, args *SetUserVerifiedArgs) (err error) {
 	if args != nil {
-		err = rpcc.Invoke(ctx, "WebAuthn.setUserVerified", args, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.setUserVerified", d.sessionID, args, nil, d.conn)
 	} else {
-		err = rpcc.Invoke(ctx, "WebAuthn.setUserVerified", nil, nil, d.conn)
+		err = rpcc.InvokeRPC(ctx, "WebAuthn.setUserVerified", d.sessionID, nil, nil, d.conn)
 	}
 	if err != nil {
 		err = &internal.OpError{Domain: "WebAuthn", Op: "SetUserVerified", Err: err}

--- a/rpcc/call.go
+++ b/rpcc/call.go
@@ -3,29 +3,37 @@ package rpcc
 import "context"
 
 type rpcCall struct {
-	Method string
-	Args   interface{}
-	Reply  interface{}
-	Error  chan error
+	Method    string
+	SessionID string
+	Args      interface{}
+	Reply     interface{}
+	Error     chan error
 }
 
 func (c *rpcCall) done(err error) {
 	c.Error <- err
 }
 
-// Invoke sends an RPC request and blocks until the response is received.
+// Deprecated: Invoke is kept for compatibility, but will be removed
+// in a later release. Please call InvokeRPC instead.
+func Invoke(ctx context.Context, method string, args, reply interface{}, conn *Conn) error {
+	return InvokeRPC(ctx, method, "", args, reply, conn)
+}
+
+// InvokeRPC sends an RPC request and blocks until the response is received.
 // This function is called by generated code but can be used to issue
 // requests manually.
-func Invoke(ctx context.Context, method string, args, reply interface{}, conn *Conn) error {
+func InvokeRPC(ctx context.Context, method, sessionID string, args, reply interface{}, conn *Conn) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	call := &rpcCall{
-		Method: method,
-		Args:   args,
-		Reply:  reply,
-		Error:  make(chan error, 1), // Do not block.
+		Method:    method,
+		SessionID: sessionID,
+		Args:      args,
+		Reply:     reply,
+		Error:     make(chan error, 1), // Do not block.
 	}
 
 	err := conn.send(ctx, call)

--- a/rpcc/conn.go
+++ b/rpcc/conn.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -98,8 +99,9 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	}
 
 	c := &Conn{
-		pending: make(map[uint64]*rpcCall),
-		streams: make(map[string]*streamClients),
+		pending:  make(map[uint64]*rpcCall),
+		streams:  make(map[string]*streamClients),
+		sessions: make(map[string]*SessionConn),
 	}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 
@@ -239,12 +241,13 @@ type Conn struct {
 
 	compressionLevel func(level int) error
 
-	mu      sync.Mutex // Protects following.
-	reqSeq  uint64
-	pending map[uint64]*rpcCall
-	streams map[string]*streamClients
-	closed  bool
-	err     error // Protected by mu and closed until context is cancelled.
+	mu       sync.Mutex // Protects following.
+	reqSeq   uint64
+	pending  map[uint64]*rpcCall
+	streams  map[string]*streamClients
+	sessions map[string]*SessionConn
+	closed   bool
+	err      error // Protected by mu and closed until context is cancelled.
 
 	reqMu sync.Mutex // Protects following.
 	req   Request
@@ -261,8 +264,9 @@ type Response struct {
 	Error  *ResponseError  `json:"error"`  // Error, if any.
 
 	// RPC notification from remote.
-	Method string          `json:"method"` // Method invokation requested by remote.
-	Args   json.RawMessage `json:"params"` // Method parameters, if any.
+	Method    string          `json:"method"` // Method invokation requested by remote.
+	SessionID string          `json:"sessionId,omitempty"`
+	Args      json.RawMessage `json:"params"` // Method parameters, if any.
 }
 
 func (r *Response) reset() {
@@ -270,17 +274,26 @@ func (r *Response) reset() {
 	r.Result = nil
 	r.Error = nil
 	r.Method = ""
+	r.SessionID = ""
 	r.Args = nil
 }
 
 func (r *Response) String() string {
+	var s []string
 	if r.Method != "" {
-		return fmt.Sprintf("Method = %s, Params = %s", r.Method, r.Args)
+		s = append(s, fmt.Sprintf("Method = %s", r.Method))
+		s = append(s, fmt.Sprintf("Params = %s", r.Args))
+	} else if r.Error != nil {
+		s = append(s, fmt.Sprintf("ID = %d", r.ID))
+		s = append(s, fmt.Sprintf("Error = %s", r.Error.Error()))
+	} else {
+		s = append(s, fmt.Sprintf("ID = %d", r.ID))
+		s = append(s, fmt.Sprintf("Result = %s", r.Result))
 	}
-	if r.Error != nil {
-		return fmt.Sprintf("ID = %d, Error = %s", r.ID, r.Error.Error())
+	if r.SessionID != "" {
+		s = append(s, fmt.Sprintf("SessionID = %s", r.SessionID))
 	}
-	return fmt.Sprintf("ID = %d, Result = %s", r.ID, r.Result)
+	return strings.Join(s, ", ")
 }
 
 // ResponseError represents the RPC response error sent by the server.
@@ -310,7 +323,7 @@ func (c *Conn) Context() context.Context {
 // recv decodes and handles RPC responses. Responses to RPC requests
 // are forwarded to the pending call, if any. RPC Notifications are
 // forwarded by calling notify, synchronously.
-func (c *Conn) recv(notify func(string, []byte), done func(error)) {
+func (c *Conn) recv(notify func(string, string, []byte), done func(error)) {
 	var resp Response
 	var err error
 	for {
@@ -325,7 +338,7 @@ func (c *Conn) recv(notify func(string, []byte), done func(error)) {
 			// Method represents the event that was triggered over the
 			// Chrome DevTools Protocol. We do not expect to receive
 			// RPC requests, if this was one, the ID field would be set.
-			notify(resp.Method, resp.Args)
+			notify(resp.Method, resp.SessionID, resp.Args)
 			continue
 		}
 
@@ -357,9 +370,10 @@ func (c *Conn) recv(notify func(string, []byte), done func(error)) {
 
 // Request represents an RPC request to be sent to the server.
 type Request struct {
-	ID     uint64      `json:"id"`               // ID chosen by client.
-	Method string      `json:"method"`           // Method invoked on remote.
-	Args   interface{} `json:"params,omitempty"` // Method parameters, if any.
+	ID        uint64      `json:"id"`     // ID chosen by client.
+	Method    string      `json:"method"` // Method invoked on remote.
+	SessionID string      `json:"sessionId,omitempty"`
+	Args      interface{} `json:"params,omitempty"` // Method parameters, if any.
 }
 
 // send returns after the call has successfully been dispatched over
@@ -389,6 +403,7 @@ func (c *Conn) send(ctx context.Context, call *rpcCall) (err error) {
 		c.reqMu.Lock()
 		c.req.ID = reqID
 		c.req.Method = call.Method
+		c.req.SessionID = call.SessionID
 		c.req.Args = call.Args
 
 		err := c.codec.WriteRequest(&c.req)
@@ -428,13 +443,19 @@ func (c *Conn) send(ctx context.Context, call *rpcCall) (err error) {
 
 // notify handles RPC notifications and sends them
 // to the appropriate stream listeners.
-func (c *Conn) notify(method string, data []byte) {
+func (c *Conn) notify(method, sessionID string, data []byte) {
 	c.mu.Lock()
-	stream := c.streams[method]
+	var streamClients *map[string]*streamClients
+	if sessionID != "" {
+		streamClients = &c.sessions[sessionID].streams
+	} else {
+		streamClients = &c.streams
+	}
+	stream := (*streamClients)[method]
 	if stream != nil {
 		// Stream writer must be able to handle incoming writes
 		// even after it has been removed (unsubscribed).
-		stream.write(method, data)
+		stream.write(method, sessionID, data)
 	}
 	c.mu.Unlock()
 }
@@ -442,7 +463,7 @@ func (c *Conn) notify(method string, data []byte) {
 // listen registers a new stream listener (chan) for the RPC notification
 // method. Returns a function for removing the listener. Error if the
 // connection is closed.
-func (c *Conn) listen(method string, w streamWriter) (func(), error) {
+func (c *Conn) listen(method, sessionID string, w streamWriter) (func(), error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -450,10 +471,16 @@ func (c *Conn) listen(method string, w streamWriter) (func(), error) {
 		return nil, c.err
 	}
 
-	stream, ok := c.streams[method]
+	var streams *map[string]*streamClients
+	if sessionID != "" {
+		streams = &c.sessions[sessionID].streams
+	} else {
+		streams = &c.streams
+	}
+	stream, ok := (*streams)[method]
 	if !ok {
 		stream = newStreamClients()
-		c.streams[method] = stream
+		(*streams)[method] = stream
 	}
 	seq := stream.add(w)
 
@@ -530,6 +557,34 @@ func (c *Conn) SetCompressionLevel(level int) error {
 // Close closes the connection.
 func (c *Conn) Close() error {
 	return c.close(nil)
+}
+
+// SessionConn is a lightweight RPC connection for sending protocol messages
+// belonging to a specific session.
+type SessionConn struct {
+	Parent    *Conn
+	SessionID string
+	streams   map[string]*streamClients
+	ctx       context.Context
+	cancel    context.CancelFunc
+}
+
+func (c *SessionConn) Context() context.Context {
+	return c.ctx
+}
+
+func (c *SessionConn) Close() error {
+	c.cancel()
+	return nil
+}
+
+func (c *Conn) NewSessionConn(sessionID string) *SessionConn {
+	s := &SessionConn{Parent: c, SessionID: sessionID,
+		streams: make(map[string]*streamClients),
+	}
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	c.sessions[sessionID] = s
+	return s
 }
 
 // Debugging, enabled in tests.

--- a/rpcc/conn_test.go
+++ b/rpcc/conn_test.go
@@ -261,7 +261,7 @@ func TestConn_Notify(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s, err := NewStream(ctx, "test.Notify", srv.conn)
+	s, err := NewStream(ctx, "test.Notify", "", srv.conn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +302,7 @@ func TestConn_StreamRecv(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s, err := NewStream(ctx, "test.Stream", srv.conn)
+	s, err := NewStream(ctx, "test.Stream", "", srv.conn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,12 +346,12 @@ func TestConn_PropagateError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s1, err := NewStream(ctx, "test.Stream1", srv.conn)
+	s1, err := NewStream(ctx, "test.Stream1", "", srv.conn)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s1.Close()
-	s2, err := NewStream(ctx, "test.Stream2", srv.conn)
+	s2, err := NewStream(ctx, "test.Stream2", "", srv.conn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpcc/stream_sync.go
+++ b/rpcc/stream_sync.go
@@ -23,7 +23,7 @@ func newSyncMessageStore() *syncMessageStore {
 	}
 }
 
-func (s *syncMessageStore) subscribe(method string, w streamWriter, conn *Conn) (unsubscribe func(), err error) {
+func (s *syncMessageStore) subscribe(method, sessionID string, w streamWriter, conn *Conn) (unsubscribe func(), err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -31,7 +31,7 @@ func (s *syncMessageStore) subscribe(method string, w streamWriter, conn *Conn) 
 		return nil, fmt.Errorf("%s already subscribed", method)
 	}
 
-	remove, err := conn.listen(method, s)
+	remove, err := conn.listen(method, sessionID, s)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func Sync(s ...Stream) (err error) {
 		}
 
 		// Allow store to manage messages to streamClient.
-		unsub, err := store.subscribe(sc.method, sc, sc.conn)
+		unsub, err := store.subscribe(sc.method, sc.sessionID, sc, sc.conn)
 		if err != nil {
 			return errors.New("rpcc: Sync: " + err.Error())
 		}

--- a/rpcc/stream_sync_test.go
+++ b/rpcc/stream_sync_test.go
@@ -17,21 +17,21 @@ func TestSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s1, err := NewStream(ctx, "test1", conn)
+	s1, err := NewStream(ctx, "test1", "", conn)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s1.Close()
 
-	s2, err := NewStream(ctx, "test2", conn)
+	s2, err := NewStream(ctx, "test2", "", conn)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s2.Close()
 
 	// These notifications should disappear after Sync.
-	conn.notify("test1", []byte(strconv.Itoa(1)))
-	conn.notify("test1", []byte(strconv.Itoa(2)))
+	conn.notify("test1", "", []byte(strconv.Itoa(1)))
+	conn.notify("test1", "", []byte(strconv.Itoa(2)))
 
 	err = Sync(s1, s2)
 	if err != nil {
@@ -40,14 +40,14 @@ func TestSync(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 3; i++ {
-			conn.notify("test1", []byte(strconv.Itoa(100+i)))
+			conn.notify("test1", "", []byte(strconv.Itoa(100+i)))
 		}
 		for i := 0; i < 3; i++ {
-			conn.notify("test2", []byte(strconv.Itoa(200+i)))
+			conn.notify("test2", "", []byte(strconv.Itoa(200+i)))
 		}
 		for i := 0; i < 4; i++ {
-			conn.notify("test1", []byte(strconv.Itoa(100+i)))
-			conn.notify("test2", []byte(strconv.Itoa(200+i)))
+			conn.notify("test1", "", []byte(strconv.Itoa(100+i)))
+			conn.notify("test2", "", []byte(strconv.Itoa(200+i)))
 		}
 	}()
 
@@ -95,25 +95,25 @@ func TestSyncError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s1, err := NewStream(ctx, "test", conn1)
+	s1, err := NewStream(ctx, "test", "", conn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s1.Close()
 
-	s2, err := NewStream(ctx, "duplicate", conn1)
+	s2, err := NewStream(ctx, "duplicate", "", conn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s2.Close()
 
-	s3, err := NewStream(ctx, "duplicate", conn1)
+	s3, err := NewStream(ctx, "duplicate", "", conn1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s3.Close()
 
-	s4, err := NewStream(ctx, "other-conn", conn2)
+	s4, err := NewStream(ctx, "other-conn", "", conn2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,17 +159,17 @@ func TestStreamSyncNotifyDeadlock(t *testing.T) {
 
 	ctx := context.Background()
 
-	s1, err := NewStream(ctx, "test1", conn)
+	s1, err := NewStream(ctx, "test1", "", conn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2, err := NewStream(ctx, "test2", conn)
+	s2, err := NewStream(ctx, "test2", "", conn)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	go conn.notify("test1", []byte(`{"hello": "world"}`))
-	go conn.notify("test2", []byte(`{"hello": "world"}`))
+	go conn.notify("test1", "", []byte(`{"hello": "world"}`))
+	go conn.notify("test2", "", []byte(`{"hello": "world"}`))
 
 	// This could cause a deadlock due to competition for same mutexes:
 	// https://github.com/mafredri/cdp/issues/90
@@ -186,11 +186,11 @@ func TestStreamSyncSameStreamDeadlock(t *testing.T) {
 
 	ctx := context.Background()
 
-	s1, err := NewStream(ctx, "test1", conn)
+	s1, err := NewStream(ctx, "test1", "", conn)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2, err := NewStream(ctx, "test2", conn)
+	s2, err := NewStream(ctx, "test2", "", conn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestStreamSyncClosingStreams(t *testing.T) {
 
 	var streams []Stream
 	for _, s := range testStreams {
-		ss, err := NewStream(ctx, s.name, conn)
+		ss, err := NewStream(ctx, s.name, "", conn)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,15 +238,15 @@ func TestStreamSyncClosingStreams(t *testing.T) {
 
 		<-readySteadyGo
 		go streams[2].Close()
-		conn.notify("test0", []byte("test0.0"))
-		conn.notify("test1", []byte("test1.0"))
-		conn.notify("test2", []byte("test2.0"))
-		conn.notify("test2", []byte("test2.1"))
-		conn.notify("test2", []byte("test2.2"))
-		conn.notify("test3", []byte("test3.0"))
-		conn.notify("test3", []byte("test3.1"))
+		conn.notify("test0", "", []byte("test0.0"))
+		conn.notify("test1", "", []byte("test1.0"))
+		conn.notify("test2", "", []byte("test2.0"))
+		conn.notify("test2", "", []byte("test2.1"))
+		conn.notify("test2", "", []byte("test2.2"))
+		conn.notify("test3", "", []byte("test3.0"))
+		conn.notify("test3", "", []byte("test3.1"))
 		streams[3].Close()
-		conn.notify("test4", []byte("test4.0"))
+		conn.notify("test4", "", []byte("test4.0"))
 	}()
 
 	for i, s := range streams {


### PR DESCRIPTION
Hi again! I made a rough sketch for the flattened protocol. It is really quite rough since I'm a novice with Go, and there are certainly some loose ends, especially around closing connections. I tried my best at keeping the integrity / design of your work intact. And upfront: thank you, I feel I learned quite a bit about how a well designed Go library looks!

The gist is, I got the unittest for the sessions in sessions_test.go to work with the flattened protocol, so this is why I figured I should post what I have thus far. If the approach in this PR is viable, I'm happy to work on fixing it / finishing it, or if you'd like to take this over that's fine too, or if some other way of getting flat sessions support makes more sense, please bring it on. Thank you. :-)

Approach taken here:
* Trying to keep this compatible with existing code, so that upgrading to this version will "just work", but not switch to flattened protocol. To switch, minor tweaks in the client code are required (see session_test.go).
* The non-flattened sessions create an rpcc.Conn instance which reads/writes to an underlying instance by sending Target.sendMessageToTarget etc. This is still the case; but to support non-flattened sessions this PR adds rpcc.SessionConn, which is much lighter weight - it carries the SessionID and can be closed, but the traffic is sent via it's parent connection, an instance of rpcc.Conn, which keeps track of its rpcc.SessionConn instances.
* Various methods and structs now have a SessionID field / sessionID argument.
* A few public method names are new, when I felt that it's better to keep the old one as is for compatibility. E.g., rpcc.Invoke (made rpcc.InvokeRPC with extra param), session.Manager.Dial (made session.Manager.Attach), and in the generated code there's cdp.Client.NewSession to get a client that talks via a specific session.