### PR TITLE
Cleanup session.Manager's handling of errors.

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -6,15 +6,16 @@ import (
 	"strings"
 )
 
-type causer interface {
+// Causer is an interface to access to its direct cause of the error.
+type Causer interface {
 	Cause() error
 }
 
 // Cause returns the underlying cause for this error, if possible.
-// If err does not implement causer.Cause(), then err is returned.
+// If err does not implement Causer.Cause(), then err is returned.
 func Cause(err error) error {
 	for err != nil {
-		if c, ok := err.(causer); ok {
+		if c, ok := err.(Causer); ok {
 			err = c.Cause()
 		} else {
 			return err
@@ -50,7 +51,7 @@ type wrapped struct {
 }
 
 var _ error = (*wrapped)(nil)
-var _ causer = (*wrapped)(nil)
+var _ Causer = (*wrapped)(nil)
 
 func (e *wrapped) Error() string {
 	return fmt.Sprintf("%s: %s", e.msg, e.err)

--- a/session/manager.go
+++ b/session/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/mafredri/cdp"
 	"github.com/mafredri/cdp/internal/errors"
 	"github.com/mafredri/cdp/protocol/target"


### PR DESCRIPTION
It turns out that cdp.ErrorCause tracks the list of causes and
returns the true cause of the problem. In the case of bug #120,
the topmost err was internal.OpError, and the ErrorCause returns
underlying websocket.CloseError.

Actually there's rpcc.closeError in the middle of cause chain,
but that's simply skipped, and therefore it fails to recognize
the error as closing.

This tracks of every step of Cause and return true if any of
these errors are closing one.