### PR TITLE
rpcc: Fix potential deadlock in stream Sync

### DIFF
--- a/rpcc/conn.go
+++ b/rpcc/conn.go
@@ -446,12 +446,12 @@ func (c *Conn) send(ctx context.Context, call *rpcCall) (err error) {
 func (c *Conn) notify(method string, data []byte) {
 	c.mu.Lock()
 	stream := c.streams[method]
+	c.mu.Unlock()
 	if stream != nil {
 		// Stream writer must be able to handle incoming writes
 		// even after it has been removed (unsubscribed).
 		stream.write(method, data)
 	}
-	c.mu.Unlock()
 }
 
 // listen registers a new stream listener (chan) for the RPC notification


### PR DESCRIPTION
The simplified Conn mutex handling introduced in #74 incorrectly moved the mutex Unlock to after stream.write. This created the opportunity for a racy mutex deadlock scenario with simultaneous writes to stream while `Sync` is being performed.

Due to it's racyness, this was only occasionally caught by `TestStreamSyncNotifyDeadlock` and evaded detection.

- rpcc: Fix potential deadlock in stream Sync
- rpcc: Improve odds of deadlock in TestStreamSyncNotifyDeadlock
